### PR TITLE
fix: clear rustls-webpki audit failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- update `Cargo.lock` to move `rustls-webpki` from `0.103.10` to `0.103.12`
- clear blocking RustSec advisories `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099`
- unblock Dependabot PR #48, whose `Rust Security Audit` check is failing on the PR merge ref

## Validation
- `cargo test`
- `CARGO_HOME=/tmp/astrotimesR-cargo-home cargo audit`