### PR TITLE
security: remediate open dependabot alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
       with:
         languages: ${{ matrix.language }}
         # CodeQL supports 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift', and 'rust'
@@ -47,6 +47,6 @@ jobs:
     # No need to build the project - CodeQL will analyze without compilation
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
       with:
         category: "/language:${{matrix.language}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **Dependencies**: Updated `quinn-proto` to 0.11.14 to remediate RustSec advisory `RUSTSEC-2026-0037`
 - **Dependencies**: Updated `rustls-webpki` to 0.103.10 to remediate GHSA-pwjx-qhcg-rvj4 (supersedes Dependabot PR #43)
+- **Dependencies**: Updated `rand` to 0.9.3 and `rustls-webpki` to 0.103.12 to remediate GitHub alerts `GHSA-cq8v-f236-94qc`, `GHSA-965h-392x-2mh5`, and `GHSA-xgp8-3hg3-c2mh`
 
 ## [0.3.3] - 2026-02-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,11 +1054,10 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1475,7 +1474,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1498,7 +1497,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1527,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
@@ -1813,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- update rand to 0.9.3 in Cargo.lock
- update rustls-webpki to 0.103.12 in Cargo.lock
- document the three remediated GitHub alerts in CHANGELOG.md

## Validation
- ./scripts/safe_local_test.sh

## Notes
- local validation still reports the allowed rand 0.8.5 audit warning through ratatui transitive tooling, but the three currently open GitHub alerts on main are the patched rand 0.9.2 and rustls-webpki 0.103.10 entries fixed here.