### PR TITLE
[codex] Replace 6-month Rust support window with rust-version contract

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,22 @@ jobs:
       - name: Build
         run: cargo build --verbose --locked
 
+  msrv:
+    name: MSRV (1.91)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        with:
+          toolchain: 1.91.1
+      - name: Build with MSRV
+        run: cargo build --verbose --locked
+      - name: Test default features with MSRV
+        run: cargo test --verbose --locked
+      - name: Test all features with MSRV
+        run: cargo test --verbose --all-features --locked
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI**: Refreshed `github/codeql-action` pinned SHAs to the current `v4` tag and kept the drift gate aligned
 - **CI**: Tightened Dependabot GitHub Actions updates to run daily with grouped maintainer-reviewed workflow pin PRs
 - **CI**: Moved the Reykjavik USNO drift validation case off a seasonal boundary date, extracted USNO drift cases into `scripts/usno_drift_cases.sh` for easier maintenance, and hardened the workflow to fail closed if the case list cannot be loaded
-- **Toolchain**: Declared a Rust support policy of latest stable plus stable releases from the last 6 months, with `rust-version` set to `1.91`
+- **Toolchain**: Replaced the 6-month Rust support window with an explicit `rust-version` contract: latest stable remains the active development target, the current release line supports stable Rust `1.91+`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it
 - **CLI**: Non-watch runs now honor saved time-sync settings and persist explicit `--city` / `--lat` / `--lon` location changes back to the user config
 - **Validation**: Bounded USNO retry budgets so validation reuses the primary day fetch and surrounding-day probes fail fast during API outages
 - **Dependencies**: Updated `clap` to 4.5.60 and `anyhow` to 1.0.102 (Dependabot PR #35)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Solunatus runs offline for core calculations and supports historical/future date
 
 ## Install
 
-Solunatus targets the latest stable Rust release and supports stable Rust releases from the last 6 months. The current minimum supported Rust version is `1.91`.
+Solunatus targets the latest stable Rust release for active development. The current release line supports stable Rust versions compatible with `rust-version = "1.91"`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it. If you need an older Rust toolchain, use an older Solunatus release that still supports it.
 
 ### From crates.io
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -10,7 +10,7 @@ Get your development environment ready for building Solunatus from source.
 - **Text editor or IDE** - VS Code recommended
 - **macOS, Linux, or Windows** with development tools
 
-Solunatus targets the latest stable Rust release and supports stable Rust releases from the last 6 months.
+Solunatus targets the latest stable Rust release for active development. The current release line supports stable Rust versions compatible with `rust-version = "1.91"`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it. If you need an older Rust toolchain, use an older Solunatus release that still supports it.
 
 ## Installing Rust
 

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -26,7 +26,7 @@ See [Quick Start Guide](quick-start.md) for detailed steps.
 - Cargo (included with Rust)
 - Git
 
-Solunatus targets the latest stable Rust release and supports stable Rust releases from the last 6 months.
+Solunatus targets the latest stable Rust release for active development. The current release line supports stable Rust versions compatible with `rust-version = "1.91"`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it. If you need an older Rust toolchain, use an older Solunatus release that still supports it.
 
 **Steps:**
 


### PR DESCRIPTION
## Summary
- replace the 6-month Rust support-window wording with an explicit `rust-version` contract
- add an MSRV CI job for Rust 1.91.1 while keeping latest-stable validation unchanged
- align README and setup/install docs with the new support policy

## Why
The prior policy was easy to state but less precise than Cargo's `rust-version` model. This change makes the support floor explicit, keeps the latest stable release as the active development target, and verifies the declared floor in CI.

## Validation
- `./scripts/safe_local_test.sh`
- `cargo +1.91.1 build --verbose --locked`
- `cargo +1.91.1 test --verbose --locked`
- `cargo +1.91.1 test --verbose --all-features --locked`