### PR TITLE
release: prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-18
+
 ### Changed
 - **CI**: Refreshed `github/codeql-action` pinned SHAs to the current `v4` tag and kept the drift gate aligned
 - **CI**: Tightened Dependabot GitHub Actions updates to run daily with grouped maintainer-reviewed workflow pin PRs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "solunatus"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solunatus"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["Mike McLarney"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Solunatus runs offline for core calculations and supports historical/future date
 
 Solunatus targets the latest stable Rust release for active development. The current release line supports stable Rust versions compatible with `rust-version = "1.91"`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it. If you need an older Rust toolchain, use an older Solunatus release that still supports it.
 
+To upgrade an existing installation from crates.io:
+
+```bash
+cargo install solunatus --force
+```
+
 ### From crates.io
 
 ```bash
@@ -150,7 +156,7 @@ Add dependency:
 
 ```toml
 [dependencies]
-solunatus = "0.3.2"
+solunatus = "0.4.0"
 chrono = "0.4"
 chrono-tz = "0.10"
 ```
@@ -197,6 +203,16 @@ CLI settings are saved to:
 ```
 
 Use `--no-save` to avoid writing configuration.
+
+## Releases
+
+Crates.io is the supported distribution channel for published releases:
+
+```bash
+cargo install solunatus
+```
+
+GitHub Releases are used for tags and release notes for each published version. They should not be treated as a guaranteed source of fresh binary artifacts unless a specific release explicitly says otherwise.
 
 ## Development
 

--- a/dist/GITHUB_RELEASE_INSTRUCTIONS.md
+++ b/dist/GITHUB_RELEASE_INSTRUCTIONS.md
@@ -1,195 +1,39 @@
 # GitHub Release Instructions
 
-## Release Tag Created
-✅ Tag `v0.1.0-beta` has been pushed to GitHub
+This file now documents the current Solunatus GitHub release flow.
 
-## Create Release via GitHub Web Interface
+## Current Policy
 
-### Step 1: Navigate to Releases
-1. Go to: https://github.com/FunKite/solunatus/releases
-2. Click **"Draft a new release"**
+- Publish the crate to crates.io first.
+- Create and push the matching Git tag after a successful publish.
+- Create a GitHub Release from that tag with curated release notes.
+- Do not attach binary artifacts unless that specific release intentionally includes a packaging step.
 
-### Step 2: Configure Release
-- **Choose a tag:** Select `v0.1.0-beta` from dropdown
-- **Release title:** `Beta 0.1 - Initial macOS Release`
-- **Check:** ☑️ Set as a pre-release
+## Release Sequence
 
-### Step 3: Add Description
+1. Confirm `Cargo.toml`, `CHANGELOG.md`, and release-facing docs are finalized.
+2. Run local validation and `cargo publish --dry-run`.
+3. Run `cargo publish`.
+4. Create and push the release tag, for example `v0.4.0`.
+5. Create the GitHub Release with notes derived from the finalized changelog entry.
 
-Copy and paste this markdown:
+## GitHub Web Flow
 
-```markdown
-# Astrotimes Beta 0.1 🌅🌕
+1. Go to [GitHub Releases](https://github.com/FunKite/solunatus/releases).
+2. Click **Draft a new release**.
+3. Select the pushed release tag.
+4. Use the version number as the release title, for example `v0.4.0`.
+5. Paste or adapt the release notes from `dist/RELEASE_NOTES.md`.
+6. Publish the release without attaching binaries unless that release explicitly includes them.
 
-**First public beta release!** High-precision astronomical CLI for macOS.
-
-## ✨ Features
-
-### Solar Calculations (NOAA Algorithms)
-- ✅ Sunrise, sunset, solar noon
-- ✅ Civil, nautical, astronomical twilight (dawn/dusk)
-- ✅ Real-time solar position (altitude, azimuth with compass)
-- ✅ **Accuracy: ±12 seconds** vs U.S. Naval Observatory
-
-### Lunar Calculations (Meeus Algorithms)
-- ✅ Moonrise, moonset times
-- ✅ Lunar phases (New, First Quarter, Full, Last Quarter)
-- ✅ Moon position (altitude, azimuth)
-- ✅ Phase angle, illumination %, angular diameter
-- ✅ Distance from Earth with size classification
-
-### User Interface
-- ✅ Interactive TUI with live-updating watch mode
-- ✅ Night mode (red text to preserve night vision)
-- ✅ Adjustable refresh rate (1-600 seconds)
-- ✅ City picker with fuzzy search (570+ cities worldwide)
-
-### Other Features
-- ✅ Auto location detection via IP geolocation
-- ✅ Manual coordinates (--lat/--lon/--elev/--tz)
-- ✅ JSON output mode for scripting
-- ✅ Configuration persistence (~/.astro_times.json)
-
-## 📦 Installation
-
-### Quick Install
-
-**Option 1: Using install script (recommended)**
-```bash
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-v0.1.0-macos-arm64.tar.gz -o solunatus.tar.gz
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/install.sh -o install.sh
-tar -xzf solunatus.tar.gz
-chmod +x install.sh
-./install.sh
-```
-
-**Option 2: Manual installation**
-```bash
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-v0.1.0-macos-arm64.tar.gz -o solunatus.tar.gz
-tar -xzf solunatus.tar.gz
-sudo cp solunatus-macos/solunatus /usr/local/bin/
-```
-
-### Verify Download
+## GitHub CLI Flow
 
 ```bash
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-v0.1.0-macos-arm64.tar.gz.sha256 -o checksum.sha256
-shasum -a 256 -c checksum.sha256
+gh release create v0.4.0 \
+  --title "v0.4.0" \
+  --notes-file dist/RELEASE_NOTES.md
 ```
 
-Expected: `solunatus-v0.1.0-macos-arm64.tar.gz: OK`
+## Historical Assets
 
-## 🚀 Quick Start
-
-```bash
-# Auto-detect location and show live watch mode
-solunatus
-
-# Specify a city
-solunatus --city "Tokyo"
-
-# Use coordinates
-solunatus --lat 40.7128 --lon=-74.0060
-
-# JSON output for scripting
-solunatus --city "Paris" --json
-```
-
-## ⌨️ Keyboard Controls (Watch Mode)
-
-| Key | Action |
-|-----|--------|
-| `q` | Quit |
-| `n` | Toggle night mode (red text) |
-| `c` | Open city picker |
-| `s` | Save current location |
-| `]` | Faster refresh (min 1s) |
-| `[` | Slower refresh (max 600s) |
-| `=` | Reset refresh rate (10s) |
-
-## 💻 System Requirements
-
-- **macOS:** 11.0 (Big Sur) or later
-- **Processor:** Apple Silicon (M1/M2/M3)
-- **Architecture:** ARM64
-
-**Intel Macs:** Build from source using `cargo build --release`
-
-## 📋 Files in This Release
-
-- **`solunatus-v0.1.0-macos-arm64.tar.gz`** (1.4 MB) - Main distributable
-- **`solunatus-v0.1.0-macos-arm64.tar.gz.sha256`** - SHA256 checksum
-- **`install.sh`** - Automatic installation script
-
-## 🐛 Known Issues
-
-- Polar regions may experience polar day/night (no sunrise/sunset)
-- Historical dates before 1900 may have reduced accuracy
-- Intel Mac support requires building from source
-
-## 📚 Documentation
-
-Full documentation: [README.md](https://github.com/FunKite/solunatus/blob/main/README.md)
-
-## 🛠️ Technical Details
-
-- **Language:** Pure Rust
-- **Binary Size:** 3.9 MB (stripped)
-- **Compiler Warnings:** Zero
-- **Dependencies:** No external astronomical calculation libraries
-
----
-
-**Built with Rust + Claude Code**
-
-Please report issues at: https://github.com/FunKite/solunatus/issues
-```
-
-### Step 4: Upload Files
-
-Drag and drop or click "Attach binaries" to upload these files:
-
-1. `dist/solunatus-v0.1.0-macos-arm64.tar.gz`
-2. `dist/solunatus-v0.1.0-macos-arm64.tar.gz.sha256`
-3. `dist/install.sh`
-
-### Step 5: Publish
-- Click **"Publish release"**
-
----
-
-## Alternative: Install GitHub CLI
-
-If you want to use the command line in the future:
-
-```bash
-brew install gh
-gh auth login
-gh release create v0.1.0-beta \
-  dist/solunatus-v0.1.0-macos-arm64.tar.gz \
-  dist/solunatus-v0.1.0-macos-arm64.tar.gz.sha256 \
-  dist/install.sh \
-  --title "Beta 0.1 - Initial macOS Release" \
-  --notes-file dist/RELEASE_NOTES.md \
-  --prerelease
-```
-
----
-
-## Files Ready for Upload
-
-Location: `dist/` directory in project root
-
-- ✅ `solunatus-v0.1.0-macos-arm64.tar.gz` (1.4 MB)
-- ✅ `solunatus-v0.1.0-macos-arm64.tar.gz.sha256` (103 bytes)
-- ✅ `install.sh` (2.2 KB, executable)
-
-## Verification
-
-After publishing, test the download:
-
-```bash
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-v0.1.0-macos-arm64.tar.gz -o test.tar.gz
-tar -xzf test.tar.gz
-./solunatus-macos/solunatus --version
-```
+The `dist/` directory still contains older packaging artifacts from early binary-distribution experiments. Treat those files as historical only; they are not part of the default modern release process.

--- a/dist/PKG_INSTALLATION.md
+++ b/dist/PKG_INSTALLATION.md
@@ -1,199 +1,31 @@
-# PKG Installer - Installation Guide
+# PKG Installer Notes
 
-## Astrotimes v0.1.0 - macOS ARM64 PKG Installer
+This file is retained for historical context only.
 
-### What is a PKG?
+## Current Release Policy
 
-A `.pkg` file is a native macOS installer package that provides a GUI installation wizard. It's the standard way to install command-line tools on macOS.
+Solunatus does not currently treat macOS PKG installers as part of the default release flow. The standard modern release path is:
 
----
+1. Publish the crate on crates.io.
+2. Tag the matching version in GitHub.
+3. Create a GitHub Release with notes only unless a release explicitly includes packaged artifacts.
 
-## Installation Methods
+## Recommended Installation Paths
 
-### Method 1: Graphical Installation (Recommended)
-
-1. **Download the PKG:**
-   ```bash
-   curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-0.1.0-macos-arm64.pkg -o solunatus.pkg
-   ```
-
-2. **Double-click** `solunatus.pkg` in Finder
-
-3. **Follow the installation wizard:**
-   - Click "Continue"
-   - Read and accept the license (if prompted)
-   - Click "Install"
-   - Enter your password when prompted (required to install to `/usr/local/bin`)
-   - Click "Close" when complete
-
-4. **Verify installation:**
-   ```bash
-   solunatus --help
-   ```
-
-### Method 2: Command-Line Installation
+Install or upgrade from crates.io:
 
 ```bash
-# Download
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-0.1.0-macos-arm64.pkg -o solunatus.pkg
-
-# Install
-sudo installer -pkg solunatus.pkg -target /
-
-# Verify
-solunatus --help
+cargo install solunatus --force
 ```
 
----
-
-## Verification
-
-### Verify Download Integrity
+Or build from source:
 
 ```bash
-# Download checksum
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0-beta/solunatus-0.1.0-macos-arm64.pkg.sha256 -o checksum.sha256
-
-# Verify
-shasum -a 256 -c checksum.sha256
+git clone https://github.com/FunKite/solunatus.git
+cd solunatus
+cargo install --path .
 ```
 
-Expected output: `solunatus-0.1.0-macos-arm64.pkg: OK`
+## Historical Artifacts
 
-**SHA256:** `23ec07ccac1b62eb33cdbf51c8518a01be962e795f02ab300be51a8f62dade11`
-
----
-
-## What Gets Installed
-
-- **Binary:** `/usr/local/bin/solunatus`
-- **Documentation:** `/usr/local/bin/README.txt`
-- **Size:** 3.9 MB (binary)
-
-The installer automatically adds `/usr/local/bin` to your PATH, so `solunatus` will be immediately available after installation.
-
----
-
-## Uninstallation
-
-To uninstall solunatus:
-
-```bash
-sudo rm /usr/local/bin/solunatus
-sudo rm /usr/local/bin/README.txt
-
-# Optional: Remove configuration
-rm ~/.astro_times.json
-```
-
-Or use `pkgutil` to check what was installed:
-
-```bash
-# List installed files
-pkgutil --files com.funkite.solunatus
-
-# Uninstall (removes package receipt)
-sudo pkgutil --forget com.funkite.solunatus
-```
-
----
-
-## Security Notes
-
-### Unsigned Package Warning
-
-This package is **unsigned** because it doesn't have an Apple Developer ID certificate. When you try to install it, macOS may show:
-
-> "solunatus-0.1.0-macos-arm64.pkg" cannot be opened because it is from an unidentified developer.
-
-**To bypass this (macOS 13+):**
-1. Right-click the PKG file
-2. Select "Open With" → "Installer"
-3. Click "Open" in the security dialog
-
-**Alternative:**
-```bash
-sudo installer -pkg solunatus.pkg -target / -allowUntrusted
-```
-
-**Why unsigned?**
-- Apple Developer ID certificates cost $99/year
-- This is a beta/private release
-- You can verify the checksum to ensure integrity
-
----
-
-## Comparison: PKG vs Tarball
-
-| Feature | PKG | Tarball (.tar.gz) |
-|---------|-----|-------------------|
-| Installation | GUI wizard | Manual copy |
-| PATH setup | Automatic | Manual |
-| Uninstallation | `pkgutil --forget` | Manual delete |
-| Root required | Yes | Only if installing to /usr/local/bin |
-| macOS native | Yes | No |
-| File size | 1.4 MB | 1.4 MB |
-
-**Recommendation:** Use PKG for simplest installation. Use tarball if you want more control over installation location.
-
----
-
-## Troubleshooting
-
-### "Package does not exist"
-- Ensure you downloaded the complete file (1.4 MB)
-- Try re-downloading
-
-### "Installation failed"
-- Check you have admin privileges
-- Ensure `/usr/local/bin` exists: `sudo mkdir -p /usr/local/bin`
-- Try command-line installation with verbose output:
-  ```bash
-  sudo installer -pkg solunatus.pkg -target / -verbose
-  ```
-
-### "Command not found" after installation
-- Verify installation: `ls -la /usr/local/bin/solunatus`
-- Check PATH: `echo $PATH | grep /usr/local/bin`
-- Restart terminal or run: `source ~/.zshrc`
-
----
-
-## System Requirements
-
-- **macOS:** 11.0 (Big Sur) or later
-- **Processor:** Apple Silicon (M1/M2/M3)
-- **Architecture:** ARM64
-- **Disk Space:** ~4 MB
-
-**Intel Macs:** This PKG is for Apple Silicon only. Build from source for Intel Macs.
-
----
-
-## Getting Started
-
-After installation:
-
-```bash
-# Auto-detect location
-solunatus
-
-# Specify a city
-solunatus --city "Tokyo"
-
-# Use coordinates
-solunatus --lat 40.7128 --lon=-74.0060
-
-# JSON output
-solunatus --city "Paris" --json
-
-# Help
-solunatus --help
-```
-
----
-
-**Release:** v0.1.0-beta (Pre-release)
-**Package ID:** com.funkite.solunatus
-**Created:** October 8, 2025
-**Built with:** Rust + Claude Code
+Older PKG and tarball assets under `dist/` were produced for earlier experiments and should not be treated as the supported install path for current releases.

--- a/dist/RELEASE_NOTES.md
+++ b/dist/RELEASE_NOTES.md
@@ -1,152 +1,33 @@
-# Astrotimes v0.1.0 - macOS Release
+# Solunatus v0.4.0 Release Notes
 
-**Release Date:** October 8, 2025
-**Platform:** macOS (Apple Silicon - ARM64)
-**Binary Size:** 3.9 MB (1.4 MB compressed)
+Release date: 2026-04-18
 
-## Download
+## Summary
 
-- **Binary Package:** `solunatus-v0.1.0-macos-arm64.tar.gz`
-- **SHA256:** `e24f53db7a578d4a0ef94b8b2ca89f1e9523ab02a51585ffdab1304a226459a8`
+This release promotes the current unreleased work into the `0.4.0` line. It includes CLI behavior fixes, USNO validation hardening, dependency and security updates, and release-policy documentation cleanup.
 
-## Installation
+## Highlights
 
-### Quick Install (Recommended)
+- Non-watch runs now honor saved time-sync settings and persist explicit `--city` / `--lat` / `--lon` changes back to the user config.
+- USNO validation now reuses the primary day fetch and fails surrounding-day retries faster during API outages.
+- The Rust support contract is now explicit: latest stable remains the active development target and the release line supports stable Rust `1.91+`.
+- Security and dependency updates include the current `rand`, `rustls-webpki`, `quinn-proto`, `chrono`, `clap`, and `anyhow` bumps captured in the changelog.
 
-```bash
-curl -L https://github.com/FunKite/solunatus/releases/download/v0.1.0/solunatus-v0.1.0-macos-arm64.tar.gz -o solunatus-v0.1.0-macos-arm64.tar.gz
-tar -xzf solunatus-v0.1.0-macos-arm64.tar.gz
-cd solunatus-macos
-./solunatus --help
-```
-
-Or use the install script:
+## Install Or Upgrade
 
 ```bash
-./install.sh
+cargo install solunatus --force
 ```
 
-### Manual Install
+If you use Solunatus as a library:
 
-```bash
-tar -xzf solunatus-v0.1.0-macos-arm64.tar.gz
-sudo cp solunatus-macos/solunatus /usr/local/bin/
-solunatus --help
+```toml
+[dependencies]
+solunatus = "0.4.0"
+chrono = "0.4"
+chrono-tz = "0.10"
 ```
 
-## System Requirements
+## Release Notes Source
 
-- **macOS:** 11.0 (Big Sur) or later
-- **Processor:** Apple Silicon (M1/M2/M3)
-- **Architecture:** ARM64
-
-**Note:** For Intel Macs, build from source using `cargo build --release`
-
-## Verify Download
-
-```bash
-shasum -a 256 -c solunatus-v0.1.0-macos-arm64.tar.gz.sha256
-```
-
-Expected output: `solunatus-v0.1.0-macos-arm64.tar.gz: OK`
-
-## Features
-
-### Solar Calculations (NOAA Algorithms)
-- ✅ Sunrise, sunset, solar noon
-- ✅ Civil, nautical, astronomical twilight (dawn/dusk)
-- ✅ Real-time solar position (altitude, azimuth with compass directions)
-- ✅ Accuracy: ±12 seconds vs U.S. Naval Observatory
-
-### Lunar Calculations (Meeus Algorithms)
-- ✅ Moonrise, moonset times
-- ✅ Lunar phases (New, First Quarter, Full, Last Quarter)
-- ✅ Moon position (altitude, azimuth)
-- ✅ Phase angle, illumination percentage, angular diameter
-- ✅ Distance from Earth with size classification
-
-### User Interface
-- ✅ Interactive TUI with live-updating watch mode
-- ✅ Night mode (red text to preserve night vision)
-- ✅ Adjustable refresh rate (1-600 seconds)
-- ✅ City picker with fuzzy search (570+ cities worldwide)
-- ✅ Keyboard controls (q=quit, s=save, n=night, etc.)
-
-### Other Features
-- ✅ Auto location detection via IP geolocation
-- ✅ Manual coordinates (--lat/--lon/--elev/--tz)
-- ✅ JSON output mode for scripting
-- ✅ Configuration persistence (~/.astro_times.json)
-- ✅ Cross-platform (macOS, Linux, Windows)
-
-## Usage Examples
-
-```bash
-# Auto-detect location and show live watch mode
-solunatus
-
-# Specify a city
-solunatus --city "Tokyo"
-
-# Use coordinates
-solunatus --lat 40.7128 --lon=-74.0060
-
-# JSON output for scripting
-solunatus --city "Paris" --json
-
-# Specific date
-solunatus --city "London" --date 2025-12-25
-```
-
-## Keyboard Controls (Watch Mode)
-
-| Key | Action |
-|-----|--------|
-| `q` | Quit |
-| `n` | Toggle night mode (red text) |
-| `c` | Open city picker |
-| `s` | Save current location |
-| `]` | Faster refresh (min 1s) |
-| `[` | Slower refresh (max 600s) |
-| `=` | Reset refresh rate (10s) |
-
-## Technical Highlights
-
-- Pure Rust implementation for maximum performance
-- No external dependencies for astronomical calculations
-- Modular architecture with clean separation of concerns
-- Comprehensive error handling with anyhow/thiserror
-- NOAA solar position algorithms
-- Meeus lunar algorithms from "Astronomical Algorithms"
-- Accuracy within 1-3 minutes of Naval Observatory data
-
-## Known Limitations
-
-- Polar regions (high latitudes) may experience polar day/night where sunrise/sunset don't occur
-- Historical dates before 1900 may have reduced accuracy
-- Requires internet connection for IP-based auto-detection (optional)
-
-## Documentation
-
-- **GitHub:** https://github.com/FunKite/solunatus
-- **Issues:** https://github.com/FunKite/solunatus/issues
-- **License:** See LICENSE file in repository
-
-## Build Information
-
-- **Rust Version:** 1.82+ (2021 edition)
-- **Build Profile:** Release (optimized)
-- **Optimizations:** LTO enabled, debug symbols stripped
-- **Compiler Warnings:** Zero
-
-## Changes Since Last Build
-
-- Fixed all compiler warnings (24 warnings resolved)
-- Improved code quality with proper attribute annotations
-- Refactored match expressions for better Rust idioms
-- Clean build with zero warnings
-
----
-
-**Built with:** Rust + Claude Code
-**Generated:** October 8, 2025
+The canonical per-release details should match the `CHANGELOG.md` entry for `0.4.0`. GitHub Releases for the default flow are tags plus notes only; do not imply binary attachments unless the release explicitly includes them.

--- a/dist/astrotimes-macos/README.txt
+++ b/dist/astrotimes-macos/README.txt
@@ -1,94 +1,17 @@
-ASTROTIMES - High-Precision Astronomical CLI for macOS
-======================================================
+HISTORICAL ARTIFACT
+===================
 
-Version: 0.1.0
-Architecture: ARM64 (Apple Silicon)
+This directory is retained only as an archive of early astrotimes packaging work.
 
-INSTALLATION
-------------
+Do not treat the files here as the supported installation or release path for current Solunatus releases.
 
-1. Copy the 'astrotimes' executable to a directory in your PATH:
+Current release policy:
 
-   sudo cp astrotimes /usr/local/bin/
+- Installable releases are published on crates.io.
+- GitHub Releases are used for tags and release notes unless a specific release explicitly includes packaged artifacts.
+- Current product documentation lives in the repository root README and the `docs/` directory.
 
-   Or add it to your user bin:
+Primary references:
 
-   mkdir -p ~/bin
-   cp astrotimes ~/bin/
-   echo 'export PATH="$HOME/bin:$PATH"' >> ~/.zshrc
-   source ~/.zshrc
-
-2. Make sure it's executable:
-
-   chmod +x /usr/local/bin/astrotimes
-   (or chmod +x ~/bin/astrotimes)
-
-QUICK START
------------
-
-# Auto-detect your location and show live watch mode:
-astrotimes
-
-# Specify a city:
-astrotimes --city "New York"
-
-# Use coordinates:
-astrotimes --lat 40.7128 --lon=-74.0060
-
-# JSON output (for scripting):
-astrotimes --city "Tokyo" --json
-
-# Help:
-astrotimes --help
-
-FEATURES
---------
-
-- NOAA solar calculations (sunrise, sunset, twilight times)
-- Meeus lunar algorithms (moonrise, moonset, phases)
-- Real-time position tracking (altitude, azimuth)
-- Interactive TUI with live updates
-- Night mode (red text - press 'n')
-- 570+ cities worldwide
-- JSON output for scripting
-- Accuracy: ±12 seconds vs U.S. Naval Observatory
-
-KEYBOARD CONTROLS (Watch Mode)
--------------------------------
-
-q     - Quit
-n     - Toggle night mode (red text)
-c     - City picker
-s     - Save current location
-]     - Faster refresh (up to 1 second)
-[     - Slower refresh (up to 600 seconds)
-=     - Reset refresh rate (10 seconds)
-
-CONFIGURATION
--------------
-
-Settings are saved to: ~/.astro_times.json
-
-DOCUMENTATION
--------------
-
-GitHub: https://github.com/FunKite/astrotimes
-
-REQUIREMENTS
-------------
-
-- macOS 11.0 (Big Sur) or later
-- Apple Silicon (M1/M2/M3) processor
-
-For Intel Macs, build from source:
-  git clone https://github.com/FunKite/astrotimes.git
-  cd astrotimes
-  cargo build --release
-
-LICENSE
--------
-
-See LICENSE file in the GitHub repository.
-
----
-Generated with Claude Code
+- Repository README: https://github.com/FunKite/solunatus/blob/main/README.md
+- Documentation index: https://github.com/FunKite/solunatus/blob/main/docs/README.md

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -62,18 +62,20 @@ If you want to use Solunatus as a library in your Rust project:
 
 ```toml
 [dependencies]
-solunatus = "0.2"
+solunatus = "0.4.0"
 chrono = "0.4"
 chrono-tz = "0.10"
 ```
 
 See the [examples directory](../../examples/) for usage patterns.
 
-### 3. Download Pre-built Binary (Linux)
+### 3. Review GitHub Release Notes
 
-Pre-built binaries for Linux are available on the [GitHub Releases](https://github.com/FunKite/solunatus/releases) page.
+GitHub Releases are used for tags and release notes for published versions:
 
-Check the releases page for available architectures and download instructions.
+- [GitHub Releases](https://github.com/FunKite/solunatus/releases)
+
+Installable releases are published on crates.io. Do not assume a GitHub Release includes fresh binary artifacts unless that specific release explicitly documents them.
 
 ## Platform Support
 

--- a/docs/installation/quick-start.md
+++ b/docs/installation/quick-start.md
@@ -131,7 +131,7 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-solunatus = "0.2"
+solunatus = "0.4.0"
 chrono = "0.4"
 chrono-tz = "0.10"
 ```


### PR DESCRIPTION
## Summary
- bump Solunatus to 0.4.0 and finalize the changelog entry
- update README, installation docs, and release-support docs for the crates.io-first release flow
- preserve historical dist artifacts as historical-only documentation

## Validation
- ./scripts/safe_local_test.sh
- cargo doc --no-deps --all-features
- cargo publish --dry-run
- cargo publish

## Release
- published crates.io release: 0.4.0
- pushed Git tag: v0.4.0
- created GitHub Release from dist/RELEASE_NOTES.md