### PR TITLE
docs(changelog): record dependency maintenance since 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Dependencies**: Bumped `clap` to 4.6.1 and `rayon` to 1.12.0 via the production-dependencies group (Dependabot PR #58)
+- **CI**: Refreshed `github/codeql-action` pinned SHA progression 4.35.2 → 4.35.3 → 4.35.4 → 4.35.5 (Dependabot PRs #59, #60, #61) to stay aligned with the tracked `v4` tag
+
 ### Security
 - **Dependencies**: Updated transitive `rand` 0.8.x usage to 0.8.6 to remediate GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097 (supersedes Dependabot PR #55)
+- **Dependencies**: Updated `rustls-webpki` to 0.103.13 (Dependabot PR #56)
 
 ## [0.4.0] - 2026-04-18
 


### PR DESCRIPTION
## Summary
- Bring the `Unreleased` section of `CHANGELOG.md` up to date with the dependency and CI maintenance that has accumulated on `main` since the 0.4.0 release.
- Capture the production-dependencies bump (`clap` 4.6.1, `rayon` 1.12.0) from PR #58, the rolling `github/codeql-action` SHA progression through 4.35.5 (PRs #59, #60, #61), and the `rustls-webpki` 0.103.13 patch (PR #56).

## Maintenance context
- PR #61 (`github/codeql-action` 4.35.4 → 4.35.5) had all 11 required checks green, including `Pin Drift Check`, `Security Workflow Audit`, and `CodeQL`. It was merged via squash to match the project's Dependabot convention.
- Local `cargo audit` against the post-merge `Cargo.lock` reports 0 advisories across 322 dependencies.

## Test plan
- [x] `cargo audit` clean
- [x] CI on this branch (Build / Clippy / Rustfmt / Feature Tests / MSRV / Documentation / Security / Pin Drift / CodeQL)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vws6Zcucgm94jDABKcxAbo)_