### PR TITLE
docs(changelog): record codeql-action 4.36.0 and serde_json 1.0.150 bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Dependencies**: Bumped `clap` to 4.6.1 and `rayon` to 1.12.0 via the production-dependencies group (Dependabot PR #58)
-- **CI**: Refreshed `github/codeql-action` pinned SHA progression 4.35.2 → 4.35.3 → 4.35.4 → 4.35.5 (Dependabot PRs #59, #60, #61) to stay aligned with the tracked `v4` tag
+- **Dependencies**: Updated `serde_json` to 1.0.150 via the production-dependencies group (Dependabot PR #64)
+- **CI**: Refreshed `github/codeql-action` pinned SHA progression 4.35.2 → 4.35.3 → 4.35.4 → 4.35.5 → 4.36.0 (Dependabot PRs #59, #60, #61, #63) to stay aligned with the tracked `v4` tag
 
 ### Security
 - **Dependencies**: Updated transitive `rand` 0.8.x usage to 0.8.6 to remediate GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097 (supersedes Dependabot PR #55)


### PR DESCRIPTION
## Summary
- Records the `github/codeql-action` bump to `4.36.0` (Dependabot PR #63, merged) in the `[Unreleased]` CI line, extending the tracked `v4` SHA progression.
- Records the `serde_json` bump to `1.0.150` (Dependabot PR #64) under `[Unreleased]` → Changed → Dependencies.

## Context
PR #63 also realigned the pinned CodeQL SHA with the live `v4` tag, which cleared the `Pin Drift Check` failure that PR #64 was showing (that check only failed because main's pin had drifted, unrelated to the `serde_json` change).

## Test plan
- [x] No code changes — documentation only.
- [x] CHANGELOG entries match the established `[Unreleased]` format and PR references.

https://claude.ai/code/session_01R1DDneFxWPgwPPsgqaedoG

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1DDneFxWPgwPPsgqaedoG)_