### PR TITLE
perf(calendar): add optional rayon-backed parallel feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Performance**: New optional `parallel` Cargo feature parallelizes multi-day calendar generation across CPU cores via rayon, using the canonical per-day algorithm so results are identical to the single-threaded path
 - **Tests**: Added a regression test that locks calendar moonrise/moonset output to the canonical `lunar_event_time` algorithm
 
 ### Changed
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - **Code Quality**: Removed unused/mislabeled optimization modules (`simd_math`, `m1_optimizations`, `moon_batch_optimized`, `calendar_optimized`) and the excluded `src/bin/*` benchmark binaries (~3,400 lines)
-- **Build**: Dropped the no-op `cpu-*`, `benchmarks`, and `parallel` Cargo features and the now-unused `rayon` dependency
+- **Build**: Dropped the no-op `cpu-*` and `benchmarks` Cargo features
 
 ### Security
 - **Time Sync**: Hardened the NTP client to connect the socket (source filtering), set and verify the originate timestamp to reject off-path/stale replies, and use the standard round-trip-corrected offset formula

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1645,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +1981,7 @@ dependencies = [
  "dirs",
  "fuzzy-matcher",
  "ratatui",
+ "rayon",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,18 @@ anyhow = "1.0"
 # System directories
 dirs = "5.0"
 
+# Data parallelism for calendar generation (optional)
+rayon = { version = "1.12", optional = true }
+
 [features]
 default = ["usno-validation", "ai-insights"]
 
 # Optional Features (require reqwest)
 usno-validation = ["dep:reqwest"]  # USNO API validation (--validate flag, 'r' key)
 ai-insights = ["dep:reqwest"]      # Ollama AI integration (--ai-insights flag, 'a' key)
+
+# Parallelize multi-day calendar generation across CPU cores (uses rayon)
+parallel = ["dep:rayon"]
 
 # Standard release profile (all platforms) - Portable baseline
 [profile.release]

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -184,19 +184,56 @@ fn collect_records(
     start: NaiveDate,
     end: NaiveDate,
 ) -> Result<Vec<DailyRecord>> {
-    let mut records = Vec::new();
+    let dates = enumerate_dates(start, end)?;
+    build_records(location, timezone, dates)
+}
+
+/// Materialize every date in `[start, end]` so the per-day work can be mapped
+/// (optionally in parallel) without re-deriving dates from an index.
+fn enumerate_dates(start: NaiveDate, end: NaiveDate) -> Result<Vec<NaiveDate>> {
+    let mut dates = Vec::new();
     let mut current = start;
 
     while current <= end {
-        let record = build_record(location, timezone, current)
-            .with_context(|| format!("Failed to compute ephemerides for {}", current))?;
-        records.push(record);
+        dates.push(current);
         current = current
             .checked_add_signed(Duration::days(1))
             .ok_or_else(|| anyhow!("Date overflow when iterating calendar range"))?;
     }
 
-    Ok(records)
+    Ok(dates)
+}
+
+#[cfg(feature = "parallel")]
+fn build_records(
+    location: &Location,
+    timezone: &Tz,
+    dates: Vec<NaiveDate>,
+) -> Result<Vec<DailyRecord>> {
+    use rayon::prelude::*;
+
+    dates
+        .into_par_iter()
+        .map(|date| {
+            build_record(location, timezone, date)
+                .with_context(|| format!("Failed to compute ephemerides for {}", date))
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "parallel"))]
+fn build_records(
+    location: &Location,
+    timezone: &Tz,
+    dates: Vec<NaiveDate>,
+) -> Result<Vec<DailyRecord>> {
+    dates
+        .into_iter()
+        .map(|date| {
+            build_record(location, timezone, date)
+                .with_context(|| format!("Failed to compute ephemerides for {}", date))
+        })
+        .collect()
 }
 
 fn build_record(location: &Location, timezone: &Tz, date: NaiveDate) -> Result<DailyRecord> {


### PR DESCRIPTION
## Summary

Reintroduces the multi-core calendar-generation speedup that was lost when the mislabeled `calendar_optimized.rs` module was removed during the code-review cleanup — but this time without the correctness pitfalls that module carried.

- Adds an optional `parallel` Cargo feature (`parallel = ["dep:rayon"]`) with `rayon` 1.12 as an optional dependency.
- `collect_records` now materializes the date range and maps `build_record` over it. With `--features parallel` it uses `into_par_iter()` to spread the per-day work across CPU cores; otherwise it falls back to a sequential `into_iter()`.
- Crucially, the parallel path runs the **canonical** per-day pipeline (`build_record` → `moon::lunar_event_time`), so parallel and single-threaded output are byte-for-byte identical. The old `calendar_optimized` path used a separate batch algorithm that could return a different horizon crossing.
- The feature is **off by default**, so the standard build and the published library API are unchanged.
- CHANGELOG updated: the no-op `parallel` feature removed earlier in this cycle is replaced by this real, rayon-backed one.

## Why

The earlier review correctly deleted dead/mislabeled SIMD modules (`simd_math`, `m1_optimizations`, `moon_batch_optimized`), but `calendar_optimized.rs` also contained a genuine rayon parallelism optimization that got dropped with them. This restores the speedup on the correct code path.

## Test plan

- [x] `cargo build --features parallel` (compiles; Cargo.lock updated with rayon)
- [x] `cargo clippy --features parallel --all-targets` (clean)
- [x] `cargo clippy --all-targets` (default features, clean)
- [x] `cargo test --features parallel` (38 passed)
- [x] `cargo test --lib calendar` (default features — canonical regression test passes)
- [x] `cargo fmt --all`

https://claude.ai/code/session_01SYioKFEbHafPn7hmjv8uiV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYioKFEbHafPn7hmjv8uiV)_