### PR TITLE
release: prepare 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-29
+
 ### Added
 - **Performance**: New optional `parallel` Cargo feature parallelizes multi-day calendar generation across CPU cores via rayon, using the canonical per-day algorithm so results are identical to the single-threaded path
 - **Tests**: Added a regression test that locks calendar moonrise/moonset output to the canonical `lunar_event_time` algorithm
 
 ### Changed
+- **Toolchain**: Migrated the crate to the Rust 2024 edition (`edition = "2024"`); the `rust-version = "1.91"` floor already satisfies the 2024 edition requirement (Rust 1.85+)
+- **Code Quality**: Collapsed nested `if let` blocks into 2024-edition let-chains across the TUI and USNO validation modules, clearing the clippy warnings surfaced by the edition bump
 - **Dependencies**: Bumped `clap` to 4.6.1 and `rayon` to 1.12.0 via the production-dependencies group (Dependabot PR #58)
 - **Dependencies**: Updated `serde_json` to 1.0.150 via the production-dependencies group (Dependabot PR #64)
 - **CI**: Refreshed `github/codeql-action` pinned SHA progression 4.35.2 → 4.35.3 → 4.35.4 → 4.35.5 → 4.36.0 (Dependabot PRs #59, #60, #61, #63) to stay aligned with the tracked `v4` tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "solunatus"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solunatus"
-version = "0.4.0"
-edition = "2021"
+version = "0.5.0"
+edition = "2024"
 rust-version = "1.91"
 authors = ["Mike McLarney"]
 description = "High-precision astronomical calculation library and CLI for sun/moon positions, rise/set times, and lunar phases"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Solunatus runs offline for core calculations and supports historical/future date
 
 ## Install
 
-Solunatus targets the latest stable Rust release for active development. The current release line supports stable Rust versions compatible with `rust-version = "1.91"`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it. If you need an older Rust toolchain, use an older Solunatus release that still supports it.
+Solunatus targets the latest stable Rust release for active development and is built on the Rust 2024 edition. The current release line supports stable Rust versions compatible with `rust-version = "1.91"`, and that floor may rise in a minor release when security, dependency compatibility, or maintainability require it. If you need an older Rust toolchain, use an older Solunatus release that still supports it.
 
 To upgrade an existing installation from crates.io:
 
@@ -149,7 +149,7 @@ Add dependency:
 
 ```toml
 [dependencies]
-solunatus = "0.4.0"
+solunatus = "0.5.0"
 chrono = "0.4"
 chrono-tz = "0.10"
 ```

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -8,7 +8,7 @@
 use chrono::Local;
 use chrono_tz::America::Denver;
 use solunatus::astro::coordinates::azimuth_to_compass;
-use solunatus::astro::sun::{solar_event_time, SolarEvent};
+use solunatus::astro::sun::{SolarEvent, solar_event_time};
 use solunatus::prelude::*;
 
 fn main() {
@@ -104,19 +104,19 @@ fn main() {
     println!("─────────────────────────────────────");
 
     for hour in [6, 9, 12, 15, 18] {
-        if let Some(time) = now.date_naive().and_hms_opt(hour, 0, 0) {
-            if let Some(datetime) = time.and_local_timezone(Denver).single() {
-                let pos = solar_position(&location, &datetime);
-                if pos.altitude > -18.0 {
-                    // Only show if sun is above astronomical twilight
-                    println!(
-                        "{:02}:00    {:>6.1}°  {:>6.0}°  {}",
-                        hour,
-                        pos.altitude,
-                        pos.azimuth,
-                        azimuth_to_compass(pos.azimuth)
-                    );
-                }
+        if let Some(time) = now.date_naive().and_hms_opt(hour, 0, 0)
+            && let Some(datetime) = time.and_local_timezone(Denver).single()
+        {
+            let pos = solar_position(&location, &datetime);
+            if pos.altitude > -18.0 {
+                // Only show if sun is above astronomical twilight
+                println!(
+                    "{:02}:00    {:>6.1}°  {:>6.0}°  {}",
+                    hour,
+                    pos.altitude,
+                    pos.azimuth,
+                    azimuth_to_compass(pos.azimuth)
+                );
             }
         }
     }

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -49,7 +49,7 @@
 //! - Configurable timeouts prevent hanging on slow networks
 //! - Error messages are truncated to prevent log spam
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use reqwest::blocking::Client;

--- a/src/astro/mod.rs
+++ b/src/astro/mod.rs
@@ -26,7 +26,7 @@ use chrono::{DateTime, Datelike, TimeZone, Timelike};
 use units::{Latitude, Longitude};
 
 // Re-export commonly used types
-pub use units::{Altitude, Azimuth, Degrees, Radians, DEG_TO_RAD, RAD_TO_DEG};
+pub use units::{Altitude, Azimuth, DEG_TO_RAD, Degrees, RAD_TO_DEG, Radians};
 
 /// Location on Earth
 /// All calculations assume sea level (0m elevation) per USNO celestial navigation convention

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -11,8 +11,8 @@
 //! - Supports BCE dates (year -999 = 1000 BCE)
 //! - Future dates up to year 3000
 
-use crate::astro::{moon, sun, Location};
-use anyhow::{anyhow, Context, Result};
+use crate::astro::{Location, moon, sun};
+use anyhow::{Context, Result, anyhow};
 use chrono::{Datelike, Duration, NaiveDate, TimeZone, Utc, Weekday};
 use chrono_tz::Tz;
 use serde::Serialize;

--- a/src/city.rs
+++ b/src/city.rs
@@ -12,8 +12,8 @@
 //! - Distance and bearing calculations
 
 use anyhow::{Context, Result};
-use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
 use serde::{Deserialize, Serialize};
 
 /// Information about a city in the database.

--- a/src/events.rs
+++ b/src/events.rs
@@ -6,7 +6,7 @@
 use chrono::{DateTime, Duration, TimeZone};
 use chrono_tz::Tz;
 
-use crate::astro::{moon, sun, Location};
+use crate::astro::{Location, moon, sun};
 
 #[derive(Clone, Copy)]
 enum EventSource {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,17 +109,17 @@ pub mod tui;
 
 // Re-export key types at crate root for convenience
 pub use astro::{
-    julian_century, julian_day, normalize_degrees, normalize_degrees_signed, Location,
+    Location, julian_century, julian_day, normalize_degrees, normalize_degrees_signed,
 };
 pub use city::{City, CityDatabase};
 pub use config::Config;
 
 // Re-export essential astronomical types
 pub use astro::moon::{
-    lunar_event_time, lunar_phases, lunar_position, phase_emoji, phase_name, LunarEvent,
-    LunarPhase, LunarPhaseType, LunarPosition,
+    LunarEvent, LunarPhase, LunarPhaseType, LunarPosition, lunar_event_time, lunar_phases,
+    lunar_position, phase_emoji, phase_name,
 };
-pub use astro::sun::{solar_event_time, solar_noon, solar_position, SolarEvent, SolarPosition};
+pub use astro::sun::{SolarEvent, SolarPosition, solar_event_time, solar_noon, solar_position};
 
 /// Prelude module containing the most commonly used types and functions.
 ///
@@ -129,17 +129,17 @@ pub use astro::sun::{solar_event_time, solar_noon, solar_position, SolarEvent, S
 /// use solunatus::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::astro::Location;
     pub use crate::astro::moon::{LunarEvent, LunarPhase, LunarPhaseType, LunarPosition};
     pub use crate::astro::sun::{SolarEvent, SolarPosition};
-    pub use crate::astro::Location;
     pub use crate::city::{City, CityDatabase};
 
     // Convenience functions
     pub use crate::{
-        batch_calculate, calculate_civil_dawn, calculate_civil_dusk, calculate_moonrise,
-        calculate_moonset, calculate_solar_noon, calculate_sunrise, calculate_sunset,
-        get_current_moon_phase, get_lunar_phases_for_month, lunar_position, solar_position,
-        BatchResult,
+        BatchResult, batch_calculate, calculate_civil_dawn, calculate_civil_dusk,
+        calculate_moonrise, calculate_moonset, calculate_solar_noon, calculate_sunrise,
+        calculate_sunset, get_current_moon_phase, get_lunar_phases_for_month, lunar_position,
+        solar_position,
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,15 +6,15 @@ use solunatus::{
     astro, calendar, city, cli, config, events, location_source, output, time_sync, tui,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::{Datelike, Duration, Local, NaiveDate, Offset, TimeZone};
 use chrono_tz::Tz;
 use clap::Parser;
 use crossterm::{
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{Terminal, backend::CrosstermBackend};
 use std::{env, fs, io};
 
 use location_source::LocationSource;

--- a/src/time_sync.rs
+++ b/src/time_sync.rs
@@ -26,7 +26,7 @@
 //! }
 //! ```
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,7 +9,7 @@ use crate::config::{self, WatchPreferences};
 use crate::events;
 use crate::location_source::LocationSource;
 use crate::time_sync::TimeSyncInfo;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Duration as ChronoDuration, Local, NaiveDate};
 use chrono_tz::Tz;
 use std::{
@@ -410,11 +410,11 @@ impl App {
     }
 
     fn expire_status_if_needed(&mut self) {
-        if let Some(timestamp) = self.status_timestamp {
-            if timestamp.elapsed() >= STATUS_TTL {
-                self.status_message = None;
-                self.status_timestamp = None;
-            }
+        if let Some(timestamp) = self.status_timestamp
+            && timestamp.elapsed() >= STATUS_TTL
+        {
+            self.status_message = None;
+            self.status_timestamp = None;
         }
     }
 
@@ -516,15 +516,15 @@ impl App {
         )?;
 
         let path = PathBuf::from(&output_path);
-        if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
-                fs::create_dir_all(parent).with_context(|| {
-                    format!(
-                        "Unable to create calendar output directory {}",
-                        parent.display()
-                    )
-                })?;
-            }
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Unable to create calendar output directory {}",
+                    parent.display()
+                )
+            })?;
         }
 
         fs::write(&path, contents)

--- a/src/tui/cache.rs
+++ b/src/tui/cache.rs
@@ -5,7 +5,7 @@
 
 use crate::astro::moon::LunarPosition;
 use crate::astro::sun::SolarPosition;
-use crate::astro::{moon, sun, Location};
+use crate::astro::{Location, moon, sun};
 use chrono::DateTime;
 use chrono_tz::Tz;
 

--- a/src/tui/drafts.rs
+++ b/src/tui/drafts.rs
@@ -5,7 +5,7 @@
 
 use crate::calendar::CalendarFormat;
 use crate::config;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Datelike, Local, NaiveDate};
 use std::path::PathBuf;
 

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -9,10 +9,10 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent};
 use std::time::Duration;
 
 pub fn handle_events(app: &mut App, timeout: Duration) -> Result<()> {
-    if event::poll(timeout)? {
-        if let Event::Key(key) = event::read()? {
-            handle_key_event(app, key)?;
-        }
+    if event::poll(timeout)?
+        && let Event::Key(key) = event::read()?
+    {
+        handle_key_event(app, key)?;
     }
     Ok(())
 }
@@ -264,18 +264,17 @@ fn handle_location_input_keys(app: &mut App, key: KeyEvent) -> Result<()> {
                                     app.location_source = LocationSource::ManualCli;
 
                                     // Find nearest city for reference
-                                    if let Ok(db) = crate::city::CityDatabase::load() {
-                                        if let Some((city, distance, bearing)) =
+                                    if let Ok(db) = crate::city::CityDatabase::load()
+                                        && let Some((city, distance, bearing)) =
                                             db.find_nearest(lat, lon)
-                                        {
-                                            let city_display = if let Some(ref state) = city.state {
-                                                format!("{},{}", city.name, state)
-                                            } else {
-                                                city.name.clone()
-                                            };
-                                            app.nearest_city_info =
-                                                Some((city_display, distance, bearing));
-                                        }
+                                    {
+                                        let city_display = if let Some(ref state) = city.state {
+                                            format!("{},{}", city.name, state)
+                                        } else {
+                                            city.name.clone()
+                                        };
+                                        app.nearest_city_info =
+                                            Some((city_display, distance, bearing));
                                     }
                                     // Check if we should return to settings
                                     if app.settings_draft.location_mode

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7,11 +7,11 @@ use crate::astro::*;
 use crate::time_sync;
 use chrono::{Offset, Utc};
 use ratatui::{
+    Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Wrap},
-    Frame,
 };
 use std::borrow::Cow;
 
@@ -117,11 +117,7 @@ fn label_with_symbol(app: &App, symbol: &str, text: String) -> String {
 }
 
 fn symbol_prefix<'a>(app: &App, symbol: &'a str) -> &'a str {
-    if app.night_mode {
-        ""
-    } else {
-        symbol
-    }
+    if app.night_mode { "" } else { symbol }
 }
 
 fn strip_symbolic_prefix(text: &str) -> &str {
@@ -799,11 +795,7 @@ fn render_location_input(f: &mut Frame, app: &App) {
     };
 
     let marker = |field: LocationInputField| {
-        if field == current_field {
-            "► "
-        } else {
-            "  "
-        }
+        if field == current_field { "► " } else { "  " }
     };
 
     let lat_display = if draft.latitude.is_empty() {

--- a/src/usno_validation.rs
+++ b/src/usno_validation.rs
@@ -37,7 +37,7 @@
 
 use crate::astro::*;
 use crate::events;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Duration as ChronoDuration, NaiveDate, NaiveTime, TimeZone, Utc};
 use chrono_tz::Tz;
 use serde::Deserialize;
@@ -316,18 +316,18 @@ fn insert_usno_events(
         .ok_or_else(|| anyhow!("Invalid USNO date"))?;
 
     for event in &usno_data.sundata {
-        if let Some(event_name) = map_usno_event_name(&event.phen, true) {
-            if let Some(dt) = parse_usno_time_to_local(&event.time, usno_date, timezone) {
-                usno_events.insert((usno_date, event_name), dt);
-            }
+        if let Some(event_name) = map_usno_event_name(&event.phen, true)
+            && let Some(dt) = parse_usno_time_to_local(&event.time, usno_date, timezone)
+        {
+            usno_events.insert((usno_date, event_name), dt);
         }
     }
 
     for event in &usno_data.moondata {
-        if let Some(event_name) = map_usno_event_name(&event.phen, false) {
-            if let Some(dt) = parse_usno_time_to_local(&event.time, usno_date, timezone) {
-                usno_events.insert((usno_date, event_name), dt);
-            }
+        if let Some(event_name) = map_usno_event_name(&event.phen, false)
+            && let Some(dt) = parse_usno_time_to_local(&event.time, usno_date, timezone)
+        {
+            usno_events.insert((usno_date, event_name), dt);
         }
     }
 
@@ -668,7 +668,7 @@ pub fn generate_html_report(report: &ValidationReport) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        escape_html, UsnoFetchPolicy, USNO_CONTEXT_FETCH_POLICY, USNO_PRIMARY_FETCH_POLICY,
+        USNO_CONTEXT_FETCH_POLICY, USNO_PRIMARY_FETCH_POLICY, UsnoFetchPolicy, escape_html,
     };
     use std::time::Duration;
 


### PR DESCRIPTION
## 0.5.0 release prep

Promotes the accumulated `[Unreleased]` work to **0.5.0** and migrates the crate to the **Rust 2024 edition**.

### Changes
- **Version**: `0.4.0` → `0.5.0` (CLI/TUI banner updates via `CARGO_PKG_VERSION`)
- **Edition**: migrated to Rust 2024 (`edition = "2024"`); existing `rust-version = "1.91"` floor already satisfies it (2024 needs 1.85+)
- **Lint/format**: applied edition-2024 rustfmt style (use-import ordering) and collapsed nested `if let` into let-chains, clearing the clippy warnings the edition bump surfaced
- **Docs**: CHANGELOG `[Unreleased]` → `[0.5.0] - 2026-05-29`; README dependency example bumped to `0.5.0` and notes the 2024 edition

The `[0.5.0]` section also carries the previously-unreleased calendar `parallel` feature, the CLI/TUI calendar convergence fix, I/O hardening, and the dependency/security maintenance landed since 0.4.0.

### Verification
- `cargo fmt --check` clean
- `cargo clippy --all-targets` clean (0 warnings)
- `cargo test` — all unit + doc tests pass
- `cargo build --release` clean
- `cargo publish --dry-run` — packaged + verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)