### PR TITLE
feat: v0.6.0 — planets (Mercury–Neptune), seasons, golden hour, ICS export, query mode, TUI planets panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Planets**: New `astro::planets` module computing apparent positions (altitude, azimuth, distance, approximate visual magnitude, solar elongation) and rise/set times for the seven major planets (Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune) from Keplerian mean elements with the major Jupiter–Saturn and Uranus perturbation terms; surfaced as a "— Planets —" text section and a `planets` array in JSON output, with a regression test anchored to the December 2020 Jupiter–Saturn great conjunction
+- **Seasons**: New `astro::seasons` module computing equinoxes and solstices (Meeus ch. 27, validated against the book's worked example) with ΔT correction to UTC; the next two seasonal events appear in text and JSON output
+- **Golden/blue hour**: Four new `SolarEvent` variants at the -4° and +6° photography thresholds (`GoldenDawnStart/End`, `GoldenDuskStart/End`), a `photo_periods` helper returning the morning/evening golden hour and blue hour ranges, golden hour entries in the events timeline, a "— Photography —" text section, and a `sun.photography` JSON block
+- **Dark-sky window**: New `events::next_dark_window` scans 36 hours ahead for the next period with the sun below -18° and the moon down (same DSD criteria as the events timeline) and reports it in the Photography section and as `dark_sky_window` in JSON
+- **Lunar apsides**: New `next_lunar_apsides` finds the next perigee and apogee (ternary-search refinement of the Meeus distance series); shown in the Moon section and as `moon.apsides` in JSON. Full moons within 360,000 km are flagged as supermoons (`is_supermoon`) in the Lunar Phases section, JSON, and ICS export
+- **iCalendar export**: `--calendar-format ics` generates an RFC 5545 calendar (sunrise/sunset/moonrise/moonset per day plus quarter lunar phases, UTC times, folded lines, deterministic UIDs) for import into calendar applications; also selectable in the TUI calendar generator
+- **Scripting query mode**: `--next <event>` prints the next occurrence of any solar, golden hour, or lunar event and exits; `--format iso|unix|local|human` controls the output. Skips the NTP check so cron/automation calls stay fast and offline
+- **Shell completions & man page**: `--completions <shell>` (bash, zsh, fish, elvish, powershell) and `--manpage` generate to stdout via `clap_complete`/`clap_mangen`
+- **TUI altitude chart**: New chart view (`g` key in watch mode) plotting sun and moon altitude across the local day with a horizon line and a "now" marker; curves are cached and respect night mode
+- **TUI planets panel**: The watch view gains a "— Planets —" section with a 60-second refresh countdown showing altitude, azimuth with compass direction, visual magnitude, and rise/set times for all seven major planets; toggleable via a new "Planets" entry in the settings Panel Visibility section, persisted as `watch.show_planets` in the config file
+
+### Fixed
+- **TUI events alignment**: Widened the events label column (16→17 normal, 14→15 night mode) so the 17-character golden hour labels no longer overflow it and push their countdown durations one column out of alignment with the other events
+
 ### Changed
 - **Dependencies**: Updated `ratatui` to 0.30.1 and `chrono` to 0.4.45 via the production-dependencies group (supersedes Dependabot PR #72); `chrono` 0.4.45 rejects a TZ offset hour of 24 to avoid a `FixedOffset` overflow, and the `ratatui` bump pulls in refreshed transitive crates (`lru` 0.18.0, `strum` 0.28.0, `bitflags` 2.13.0, and the new `palette` color stack). Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **TUI events alignment**: Widened the events label column (16→17 normal, 14→15 night mode) so the 17-character golden hour labels no longer overflow it and push their countdown durations one column out of alignment with the other events
+- **ICS phase boundary**: The iCalendar export now scans one UTC month past each end of the requested range when collecting quarter lunar phases, so a phase whose UTC timestamp falls in the neighboring month but whose local date is inside the range (e.g. the 2026-12-01 06:14 UTC last quarter, which is Nov 30 in America/Los_Angeles) is no longer dropped
 
 ### Changed
 - **Dependencies**: Updated `ratatui` to 0.30.1 and `chrono` to 0.4.45 via the production-dependencies group (supersedes Dependabot PR #72); `chrono` 0.4.45 rejects a TZ offset hour of 24 to avoid a `FixedOffset` overflow, and the `ratatui` bump pulls in refreshed transitive crates (`lru` 0.18.0, `strum` 0.28.0, `bitflags` 2.13.0, and the new `palette` color stack). Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -256,6 +256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +281,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -536,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1877,6 +1896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,7 +1926,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2091,17 +2116,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "solunatus"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
  "chrono-tz",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "crossterm",
  "dirs",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solunatus"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Mike McLarney"]
@@ -35,6 +35,8 @@ path = "src/main.rs"
 [dependencies]
 # CLI and terminal UI
 clap = { version = "4.6", features = ["derive"] }
+clap_complete = "4.5"
+clap_mangen = "0.2"
 ratatui = "0.30"
 crossterm = "0.29"
 

--- a/src/astro/mod.rs
+++ b/src/astro/mod.rs
@@ -18,6 +18,8 @@
 
 pub mod coordinates;
 pub mod moon;
+pub mod planets;
+pub mod seasons;
 pub mod sun;
 pub mod time_utils;
 pub mod units;

--- a/src/astro/moon.rs
+++ b/src/astro/moon.rs
@@ -483,7 +483,7 @@ fn lunar_phase_jde(k: f64, phase_type: LunarPhaseType) -> f64 {
 /// Convert Julian Day to DateTime
 ///
 /// Returns `None` if the resulting date is invalid (extremely rare edge case).
-fn jd_to_datetime(jd: f64) -> Option<DateTime<chrono::Utc>> {
+pub(crate) fn jd_to_datetime(jd: f64) -> Option<DateTime<chrono::Utc>> {
     use chrono::Utc;
 
     let jd0 = jd + 0.5;
@@ -662,6 +662,134 @@ pub fn lunar_event_time<T: TimeZone>(
     }
 }
 
+/// Kind of lunar apsis (orbital distance extremum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LunarApsisKind {
+    /// Perigee (moon closest to Earth, ~356,000–370,000 km)
+    Perigee,
+    /// Apogee (moon farthest from Earth, ~404,000–407,000 km)
+    Apogee,
+}
+
+/// A lunar apsis event: the moment the moon reaches perigee or apogee.
+#[derive(Debug, Clone)]
+pub struct LunarApsis {
+    /// Whether this is a perigee or apogee
+    pub kind: LunarApsisKind,
+    /// UTC time of the distance extremum
+    pub datetime: DateTime<chrono::Utc>,
+    /// Earth–moon distance at the extremum in kilometers
+    pub distance_km: f64,
+}
+
+/// Full moons at or closer than this distance are commonly called supermoons.
+pub const SUPERMOON_DISTANCE_KM: f64 = 360_000.0;
+
+fn lunar_distance_at_jd(jd: f64) -> f64 {
+    moon_distance(julian_century(jd))
+}
+
+/// Refine a bracketed distance extremum with ternary search (sub-minute precision).
+fn refine_apsis(mut lo_jd: f64, mut hi_jd: f64, minimize: bool) -> Option<LunarApsis> {
+    for _ in 0..50 {
+        let third = (hi_jd - lo_jd) / 3.0;
+        let m1 = lo_jd + third;
+        let m2 = hi_jd - third;
+        let f1 = lunar_distance_at_jd(m1);
+        let f2 = lunar_distance_at_jd(m2);
+        if (f1 < f2) == minimize {
+            hi_jd = m2;
+        } else {
+            lo_jd = m1;
+        }
+    }
+
+    let jd = (lo_jd + hi_jd) / 2.0;
+    Some(LunarApsis {
+        kind: if minimize {
+            LunarApsisKind::Perigee
+        } else {
+            LunarApsisKind::Apogee
+        },
+        datetime: jd_to_datetime(jd)?,
+        distance_km: lunar_distance_at_jd(jd),
+    })
+}
+
+/// Find the next lunar perigee and apogee after a given time.
+///
+/// Scans 30 days forward (one full anomalistic month plus margin) for the
+/// distance extrema of the lunar orbit and refines each to sub-minute
+/// precision. Distances reflect the same truncated Meeus series used by
+/// [`lunar_position`], so extremum distances are approximate to within a
+/// few hundred kilometers.
+///
+/// # Returns
+///
+/// The next perigee and apogee in chronological order. Normally both are
+/// present; an entry can only be missing in the (practically unreachable)
+/// case that the extremum's time cannot be represented as a valid date.
+///
+/// # Examples
+///
+/// ```
+/// use solunatus::astro::moon::{next_lunar_apsides, LunarApsisKind};
+/// use chrono::Utc;
+///
+/// let apsides = next_lunar_apsides(&Utc::now());
+/// for apsis in apsides {
+///     println!("{:?}: {} at {:.0} km", apsis.kind, apsis.datetime, apsis.distance_km);
+/// }
+/// ```
+#[must_use]
+pub fn next_lunar_apsides<T: TimeZone>(after: &DateTime<T>) -> Vec<LunarApsis> {
+    const STEP_DAYS: f64 = 1.0 / 24.0; // 1-hour sampling
+    const HORIZON_DAYS: f64 = 30.0;
+
+    let start_jd = julian_day(after);
+    let mut perigee: Option<LunarApsis> = None;
+    let mut apogee: Option<LunarApsis> = None;
+
+    let mut prev2 = lunar_distance_at_jd(start_jd);
+    let mut prev1 = lunar_distance_at_jd(start_jd + STEP_DAYS);
+    let mut offset = 2.0 * STEP_DAYS;
+
+    while offset <= HORIZON_DAYS {
+        let jd = start_jd + offset;
+        let current = lunar_distance_at_jd(jd);
+        let mid_jd = jd - STEP_DAYS;
+
+        if prev1 < prev2 && prev1 < current && perigee.is_none() {
+            perigee = refine_apsis(mid_jd - STEP_DAYS, mid_jd + STEP_DAYS, true);
+        } else if prev1 > prev2 && prev1 > current && apogee.is_none() {
+            apogee = refine_apsis(mid_jd - STEP_DAYS, mid_jd + STEP_DAYS, false);
+        }
+
+        if perigee.is_some() && apogee.is_some() {
+            break;
+        }
+
+        prev2 = prev1;
+        prev1 = current;
+        offset += STEP_DAYS;
+    }
+
+    let mut apsides: Vec<LunarApsis> = [perigee, apogee].into_iter().flatten().collect();
+    apsides.sort_by_key(|apsis| apsis.datetime);
+    apsides
+}
+
+/// Whether a lunar phase event is a supermoon.
+///
+/// Uses the common definition: a full moon whose Earth–moon distance is at
+/// most [`SUPERMOON_DISTANCE_KM`] (360,000 km). Always `false` for phases
+/// other than full moon.
+#[must_use]
+pub fn is_supermoon(phase: &LunarPhase) -> bool {
+    phase.phase_type == LunarPhaseType::FullMoon
+        && lunar_distance_at_jd(julian_day(&phase.datetime)) <= SUPERMOON_DISTANCE_KM
+}
+
 /// Get the descriptive name of a lunar phase from its phase angle.
 ///
 /// Converts a numeric phase angle to a human-readable phase name.
@@ -756,6 +884,64 @@ mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
     use std::collections::HashSet;
+
+    #[test]
+    fn apsides_have_physical_distances_and_ordering() {
+        let after = Utc.with_ymd_and_hms(2025, 10, 1, 0, 0, 0).unwrap();
+        let apsides = next_lunar_apsides(&after);
+
+        assert_eq!(apsides.len(), 2, "expected one perigee and one apogee");
+
+        let perigee = apsides
+            .iter()
+            .find(|a| a.kind == LunarApsisKind::Perigee)
+            .expect("perigee");
+        let apogee = apsides
+            .iter()
+            .find(|a| a.kind == LunarApsisKind::Apogee)
+            .expect("apogee");
+
+        // Physical bounds of the lunar orbit (with margin for the truncated series).
+        assert!(
+            (354_000.0..=372_000.0).contains(&perigee.distance_km),
+            "perigee distance {} km out of range",
+            perigee.distance_km
+        );
+        assert!(
+            (402_000.0..=408_000.0).contains(&apogee.distance_km),
+            "apogee distance {} km out of range",
+            apogee.distance_km
+        );
+
+        for apsis in &apsides {
+            assert!(apsis.datetime > after);
+            let days_ahead = apsis.datetime.signed_duration_since(after).num_days();
+            assert!(days_ahead <= 30, "apsis {} days ahead", days_ahead);
+        }
+    }
+
+    #[test]
+    fn nov_2025_full_moon_is_supermoon() {
+        // The November 2025 full moon (Nov 5) was the closest of the year
+        // (~356,980 km), well inside the 360,000 km supermoon threshold.
+        let phases = lunar_phases(2025, 11);
+        let full = phases
+            .iter()
+            .find(|p| p.phase_type == LunarPhaseType::FullMoon)
+            .expect("full moon in Nov 2025");
+        assert!(
+            is_supermoon(full),
+            "Nov 2025 full moon should be a supermoon"
+        );
+
+        // A full moon near apogee must not be flagged: April 2025 (micro moon).
+        let phases = lunar_phases(2025, 4);
+        let full = phases
+            .iter()
+            .find(|p| p.phase_type == LunarPhaseType::FullMoon)
+            .expect("full moon in Apr 2025");
+        assert!(!is_supermoon(full), "Apr 2025 full moon is a micromoon");
+    }
 
     #[test]
     fn oct_2025_full_moon_matches_usno() {

--- a/src/astro/planets.rs
+++ b/src/astro/planets.rs
@@ -1,0 +1,634 @@
+//! Planetary position calculations for the major planets
+//! (Mercury through Neptune).
+//!
+//! Positions are computed from Keplerian mean orbital elements with the major
+//! Jupiter–Saturn and Uranus perturbation terms applied, following the method
+//! described by Paul Schlyter ("How to compute planetary positions") with mean
+//! elements consistent with Jean Meeus, "Astronomical Algorithms", Chapter 31.
+//!
+//! # Accuracy
+//!
+//! Apparent positions are accurate to roughly 1–2 arcminutes for the inner
+//! planets and a few arcminutes for the outer planets, which keeps rise/set
+//! times within about ±1–2 minutes of authoritative ephemerides.
+
+use super::*;
+use chrono::{DateTime, Duration, TimeZone};
+
+/// The major planets supported by this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Planet {
+    /// Mercury (innermost planet, twilight object near the sun)
+    Mercury,
+    /// Venus (brightest planet, morning/evening star)
+    Venus,
+    /// Mars (the red planet)
+    Mars,
+    /// Jupiter (largest planet)
+    Jupiter,
+    /// Saturn (ringed planet)
+    Saturn,
+    /// Uranus (borderline naked-eye under dark skies)
+    Uranus,
+    /// Neptune (binocular/telescope object)
+    Neptune,
+}
+
+impl Planet {
+    /// All supported planets in distance order from the sun.
+    pub const ALL: [Planet; 7] = [
+        Planet::Mercury,
+        Planet::Venus,
+        Planet::Mars,
+        Planet::Jupiter,
+        Planet::Saturn,
+        Planet::Uranus,
+        Planet::Neptune,
+    ];
+
+    /// Planet name (e.g. "Venus").
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        match self {
+            Planet::Mercury => "Mercury",
+            Planet::Venus => "Venus",
+            Planet::Mars => "Mars",
+            Planet::Jupiter => "Jupiter",
+            Planet::Saturn => "Saturn",
+            Planet::Uranus => "Uranus",
+            Planet::Neptune => "Neptune",
+        }
+    }
+
+    /// Astronomical symbol for the planet.
+    #[must_use]
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            Planet::Mercury => "☿",
+            Planet::Venus => "♀",
+            Planet::Mars => "♂",
+            Planet::Jupiter => "♃",
+            Planet::Saturn => "♄",
+            Planet::Uranus => "♅",
+            Planet::Neptune => "♆",
+        }
+    }
+}
+
+/// Apparent position and brightness of a planet as seen from a location.
+#[derive(Debug, Clone, Copy)]
+pub struct PlanetPosition {
+    /// Altitude in degrees above the horizon (negative if below horizon)
+    pub altitude: f64,
+    /// Azimuth in degrees from North (0=N, 90=E, 180=S, 270=W)
+    pub azimuth: f64,
+    /// Geocentric distance in astronomical units
+    pub distance_au: f64,
+    /// Approximate visual magnitude (lower is brighter)
+    pub magnitude: f64,
+    /// Angular distance from the sun in degrees (solar elongation)
+    pub elongation: f64,
+}
+
+/// Types of planetary events that can be calculated.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PlanetEvent {
+    /// Planet rises above the horizon
+    Rise,
+    /// Planet sets below the horizon
+    Set,
+}
+
+/// Rise/set altitude threshold: standard 34' atmospheric refraction at the
+/// horizon (planetary disks are small enough to ignore).
+const RISE_SET_ALTITUDE: f64 = -0.5667;
+
+/// Keplerian orbital elements at a given epoch (angles in degrees).
+struct Elements {
+    /// Longitude of the ascending node
+    n: f64,
+    /// Inclination to the ecliptic
+    i: f64,
+    /// Argument of perihelion
+    w: f64,
+    /// Semi-major axis in AU
+    a: f64,
+    /// Eccentricity
+    e: f64,
+    /// Mean anomaly
+    m: f64,
+}
+
+/// Day number used by the element polynomials: days from 2000 Jan 0.0 TT.
+fn day_number(jd: f64) -> f64 {
+    jd - 2451543.5
+}
+
+fn planet_elements(planet: Planet, d: f64) -> Elements {
+    match planet {
+        Planet::Mercury => Elements {
+            n: 48.3313 + 3.24587e-5 * d,
+            i: 7.0047 + 5.00e-8 * d,
+            w: 29.1241 + 1.01444e-5 * d,
+            a: 0.387098,
+            e: 0.205635 + 5.59e-10 * d,
+            m: 168.6562 + 4.0923344368 * d,
+        },
+        Planet::Venus => Elements {
+            n: 76.6799 + 2.46590e-5 * d,
+            i: 3.3946 + 2.75e-8 * d,
+            w: 54.8910 + 1.38374e-5 * d,
+            a: 0.723330,
+            e: 0.006773 - 1.302e-9 * d,
+            m: 48.0052 + 1.6021302244 * d,
+        },
+        Planet::Mars => Elements {
+            n: 49.5574 + 2.11081e-5 * d,
+            i: 1.8497 - 1.78e-8 * d,
+            w: 286.5016 + 2.92961e-5 * d,
+            a: 1.523688,
+            e: 0.093405 + 2.516e-9 * d,
+            m: 18.6021 + 0.5240207766 * d,
+        },
+        Planet::Jupiter => Elements {
+            n: 100.4542 + 2.76854e-5 * d,
+            i: 1.3030 - 1.557e-7 * d,
+            w: 273.8777 + 1.64505e-5 * d,
+            a: 5.20256,
+            e: 0.048498 + 4.469e-9 * d,
+            m: 19.8950 + 0.0830853001 * d,
+        },
+        Planet::Saturn => Elements {
+            n: 113.6634 + 2.38980e-5 * d,
+            i: 2.4886 - 1.081e-7 * d,
+            w: 339.3939 + 2.97661e-5 * d,
+            a: 9.55475,
+            e: 0.055546 - 9.499e-9 * d,
+            m: 316.9670 + 0.0334442282 * d,
+        },
+        Planet::Uranus => Elements {
+            n: 74.0005 + 1.3978e-5 * d,
+            i: 0.7733 + 1.9e-8 * d,
+            w: 96.6612 + 3.0565e-5 * d,
+            a: 19.18171 - 1.55e-8 * d,
+            e: 0.047318 + 7.45e-9 * d,
+            m: 142.5905 + 0.011725806 * d,
+        },
+        Planet::Neptune => Elements {
+            n: 131.7806 + 3.0173e-5 * d,
+            i: 1.7700 - 2.55e-7 * d,
+            w: 272.8461 - 6.027e-6 * d,
+            a: 30.05826 + 3.313e-8 * d,
+            e: 0.008606 + 2.15e-9 * d,
+            m: 260.2471 + 0.005995147 * d,
+        },
+    }
+}
+
+/// Solve Kepler's equation E - e·sin(E) = M by Newton iteration (radians).
+fn eccentric_anomaly(m_rad: f64, e: f64) -> f64 {
+    let mut big_e = m_rad + e * m_rad.sin() * (1.0 + e * m_rad.cos());
+    for _ in 0..20 {
+        let delta = (big_e - e * big_e.sin() - m_rad) / (1.0 - e * big_e.cos());
+        big_e -= delta;
+        if delta.abs() < 1e-9 {
+            break;
+        }
+    }
+    big_e
+}
+
+/// Heliocentric ecliptic position (longitude °, latitude °, radius AU).
+fn heliocentric_position(planet: Planet, d: f64) -> (f64, f64, f64) {
+    let el = planet_elements(planet, d);
+    let m_rad = normalize_degrees(el.m) * DEG_TO_RAD;
+    let big_e = eccentric_anomaly(m_rad, el.e);
+
+    let xv = el.a * (big_e.cos() - el.e);
+    let yv = el.a * ((1.0 - el.e * el.e).sqrt() * big_e.sin());
+    let v = yv.atan2(xv); // true anomaly (radians)
+    let r = (xv * xv + yv * yv).sqrt();
+
+    let n_rad = el.n * DEG_TO_RAD;
+    let i_rad = el.i * DEG_TO_RAD;
+    let vw = v + el.w * DEG_TO_RAD;
+
+    let xh = r * (n_rad.cos() * vw.cos() - n_rad.sin() * vw.sin() * i_rad.cos());
+    let yh = r * (n_rad.sin() * vw.cos() + n_rad.cos() * vw.sin() * i_rad.cos());
+    let zh = r * (vw.sin() * i_rad.sin());
+
+    let mut lon = yh.atan2(xh) * RAD_TO_DEG;
+    let mut lat = (zh / r).asin() * RAD_TO_DEG;
+
+    // Major perturbations among Jupiter, Saturn, and Uranus (degrees).
+    if matches!(planet, Planet::Jupiter | Planet::Saturn | Planet::Uranus) {
+        let mj = normalize_degrees(planet_elements(Planet::Jupiter, d).m) * DEG_TO_RAD;
+        let ms = normalize_degrees(planet_elements(Planet::Saturn, d).m) * DEG_TO_RAD;
+        let deg = DEG_TO_RAD;
+        match planet {
+            Planet::Jupiter => {
+                lon += -0.332 * (2.0 * mj - 5.0 * ms - 67.6 * deg).sin()
+                    - 0.056 * (2.0 * mj - 2.0 * ms + 21.0 * deg).sin()
+                    + 0.042 * (3.0 * mj - 5.0 * ms + 21.0 * deg).sin()
+                    - 0.036 * (mj - 2.0 * ms).sin()
+                    + 0.022 * (mj - ms).cos()
+                    + 0.023 * (2.0 * mj - 3.0 * ms + 52.0 * deg).sin()
+                    - 0.016 * (mj - 5.0 * ms - 69.0 * deg).sin();
+            }
+            Planet::Saturn => {
+                lon += 0.812 * (2.0 * mj - 5.0 * ms - 67.6 * deg).sin()
+                    - 0.229 * (2.0 * mj - 4.0 * ms - 2.0 * deg).cos()
+                    + 0.119 * (mj - 2.0 * ms - 3.0 * deg).sin()
+                    + 0.046 * (2.0 * mj - 6.0 * ms - 69.0 * deg).sin()
+                    + 0.014 * (mj - 3.0 * ms + 32.0 * deg).sin();
+                lat += -0.020 * (2.0 * mj - 4.0 * ms - 2.0 * deg).cos()
+                    + 0.018 * (2.0 * mj - 6.0 * ms - 49.0 * deg).sin();
+            }
+            Planet::Uranus => {
+                let mu = normalize_degrees(planet_elements(Planet::Uranus, d).m) * DEG_TO_RAD;
+                lon += 0.040 * (ms - 2.0 * mu + 6.0 * deg).sin()
+                    + 0.035 * (ms - 3.0 * mu + 33.0 * deg).sin()
+                    - 0.015 * (mj - mu + 20.0 * deg).sin();
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    (normalize_degrees(lon), lat, r)
+}
+
+/// Earth–sun vector: geocentric ecliptic longitude of the sun (°) and
+/// the Earth–sun distance (AU).
+fn sun_position_ecliptic(d: f64) -> (f64, f64) {
+    let w = 282.9404 + 4.70935e-5 * d;
+    let e = 0.016709 - 1.151e-9 * d;
+    let m = normalize_degrees(356.0470 + 0.9856002585 * d);
+
+    let m_rad = m * DEG_TO_RAD;
+    let big_e = eccentric_anomaly(m_rad, e);
+
+    let xv = big_e.cos() - e;
+    let yv = (1.0 - e * e).sqrt() * big_e.sin();
+    let v = yv.atan2(xv) * RAD_TO_DEG;
+    let r = (xv * xv + yv * yv).sqrt();
+
+    (normalize_degrees(v + w), r)
+}
+
+/// Geocentric ecliptic state of a planet at a Julian Day:
+/// (longitude °, latitude °, geocentric distance AU, heliocentric distance AU,
+/// Earth–sun distance AU).
+fn geocentric_ecliptic(planet: Planet, jd: f64) -> (f64, f64, f64, f64, f64) {
+    let d = day_number(jd);
+
+    let (hl, hb, r) = heliocentric_position(planet, d);
+    let (sun_lon, rs) = sun_position_ecliptic(d);
+
+    let hl_rad = hl * DEG_TO_RAD;
+    let hb_rad = hb * DEG_TO_RAD;
+    let xh = r * hb_rad.cos() * hl_rad.cos();
+    let yh = r * hb_rad.cos() * hl_rad.sin();
+    let zh = r * hb_rad.sin();
+
+    let sun_lon_rad = sun_lon * DEG_TO_RAD;
+    let xs = rs * sun_lon_rad.cos();
+    let ys = rs * sun_lon_rad.sin();
+
+    let xg = xh + xs;
+    let yg = yh + ys;
+    let zg = zh;
+
+    let dist = (xg * xg + yg * yg + zg * zg).sqrt();
+    let lon = normalize_degrees(yg.atan2(xg) * RAD_TO_DEG);
+    let lat = (zg / dist).asin() * RAD_TO_DEG;
+
+    (lon, lat, dist, r, rs)
+}
+
+/// Approximate visual magnitude from heliocentric distance `r`, geocentric
+/// distance `dist`, phase angle `fv` (degrees), and for Saturn the ring
+/// opening angle derived from the geocentric ecliptic coordinates.
+fn visual_magnitude(planet: Planet, r: f64, dist: f64, fv: f64, lon: f64, lat: f64, d: f64) -> f64 {
+    let base = 5.0 * (r * dist).log10();
+    match planet {
+        Planet::Mercury => -0.36 + base + 0.027 * fv + 2.2e-13 * fv.powi(6),
+        Planet::Venus => -4.34 + base + 0.013 * fv + 4.2e-7 * fv.powi(3),
+        Planet::Mars => -1.51 + base + 0.016 * fv,
+        Planet::Jupiter => -9.25 + base + 0.014 * fv,
+        Planet::Saturn => {
+            // Ring plane geometry (Schlyter): tilt of the rings as seen from Earth.
+            let ir = 28.06 * DEG_TO_RAD;
+            let nr = (169.51 + 3.82e-5 * d) * DEG_TO_RAD;
+            let lat_rad = lat * DEG_TO_RAD;
+            let lon_rad = lon * DEG_TO_RAD;
+            let b =
+                (lat_rad.sin() * ir.cos() - lat_rad.cos() * ir.sin() * (lon_rad - nr).sin()).asin();
+            let ring_magn = -2.6 * b.sin().abs() + 1.2 * b.sin().powi(2);
+            -9.0 + base + 0.044 * fv + ring_magn
+        }
+        Planet::Uranus => -7.15 + base + 0.001 * fv,
+        Planet::Neptune => -6.90 + base + 0.001 * fv,
+    }
+}
+
+/// Calculate the apparent position of a planet at a specific time and location.
+///
+/// # Examples
+///
+/// ```
+/// use solunatus::prelude::*;
+/// use solunatus::astro::planets::{planet_position, Planet};
+/// use chrono::Local;
+/// use chrono_tz::America::New_York;
+///
+/// let location = Location::new(40.7128, -74.0060).unwrap();
+/// let now = Local::now().with_timezone(&New_York);
+/// let venus = planet_position(Planet::Venus, &location, &now);
+///
+/// println!("Venus: Alt {:.1}°, Az {:.0}°, mag {:.1}", venus.altitude, venus.azimuth, venus.magnitude);
+/// ```
+#[must_use]
+pub fn planet_position<T: TimeZone>(
+    planet: Planet,
+    location: &Location,
+    dt: &DateTime<T>,
+) -> PlanetPosition {
+    let jd = julian_day(dt);
+    let t = julian_century(jd);
+    let d = day_number(jd);
+
+    let (lon, lat, dist, r, rs) = geocentric_ecliptic(planet, jd);
+
+    // Phase angle from the triangle sun–planet–earth.
+    let cos_fv = ((r * r + dist * dist - rs * rs) / (2.0 * r * dist)).clamp(-1.0, 1.0);
+    let fv = cos_fv.acos() * RAD_TO_DEG;
+
+    let magnitude = visual_magnitude(planet, r, dist, fv, lon, lat, d);
+
+    // Solar elongation: angle between the geocentric directions of planet and sun.
+    let (sun_lon, _) = sun_position_ecliptic(d);
+    let lat_rad = lat * DEG_TO_RAD;
+    let cos_elong = (lat_rad.cos() * ((lon - sun_lon) * DEG_TO_RAD).cos()).clamp(-1.0, 1.0);
+    let elongation = cos_elong.acos() * RAD_TO_DEG;
+
+    // Ecliptic → equatorial.
+    let ecl = (23.4393 - 3.563e-7 * d) * DEG_TO_RAD;
+    let lon_rad = lon * DEG_TO_RAD;
+    let xg = lat_rad.cos() * lon_rad.cos();
+    let yg = lat_rad.cos() * lon_rad.sin();
+    let zg = lat_rad.sin();
+
+    let xe = xg;
+    let ye = yg * ecl.cos() - zg * ecl.sin();
+    let ze = yg * ecl.sin() + zg * ecl.cos();
+
+    let ra = ye.atan2(xe) * RAD_TO_DEG;
+    let dec = ze.atan2((xe * xe + ye * ye).sqrt());
+
+    // Equatorial → horizontal via Greenwich Mean Sidereal Time.
+    let gmst = 280.46061837 + 360.98564736629 * (jd - 2451545.0) + 0.000387933 * t * t
+        - t * t * t / 38710000.0;
+    let lst = normalize_degrees(gmst + location.longitude.value());
+    let ha = normalize_degrees_signed(lst - ra) * DEG_TO_RAD;
+
+    let phi = location.latitude.value() * DEG_TO_RAD;
+    let sin_alt = phi.sin() * dec.sin() + phi.cos() * dec.cos() * ha.cos();
+    let altitude = sin_alt.asin() * RAD_TO_DEG;
+
+    let altitude_rad = altitude * DEG_TO_RAD;
+    let cos_az = (dec.sin() - phi.sin() * altitude_rad.sin()) / (phi.cos() * altitude_rad.cos());
+    let sin_az = -ha.sin() * dec.cos() / altitude_rad.cos();
+    let mut azimuth = sin_az.atan2(cos_az) * RAD_TO_DEG;
+    if azimuth < 0.0 {
+        azimuth += 360.0;
+    }
+
+    PlanetPosition {
+        altitude,
+        azimuth,
+        distance_au: dist,
+        magnitude,
+        elongation,
+    }
+}
+
+fn refine_planet_crossing<T: TimeZone>(
+    planet: Planet,
+    location: &Location,
+    mut low: DateTime<T>,
+    mut high: DateTime<T>,
+    seek_rising: bool,
+) -> DateTime<T> {
+    while (high.timestamp() - low.timestamp()).abs() > 1 {
+        let span_secs = high.timestamp() - low.timestamp();
+        let mid = low
+            .clone()
+            .checked_add_signed(Duration::seconds(span_secs / 2))
+            .unwrap();
+        let mid_alt = planet_position(planet, location, &mid).altitude - RISE_SET_ALTITUDE;
+
+        if seek_rising {
+            if mid_alt >= 0.0 {
+                high = mid;
+            } else {
+                low = mid;
+            }
+        } else if mid_alt <= 0.0 {
+            high = mid;
+        } else {
+            low = mid;
+        }
+    }
+
+    high
+}
+
+/// Calculate the time of a planetary event (rise or set) for a given date.
+///
+/// Finds when the planet crosses the refracted horizon, sweeping the local
+/// day in 10-minute steps and refining each crossing to one-second resolution.
+///
+/// # Returns
+///
+/// - `Some(DateTime)` - The time when the event occurs in the input timezone
+/// - `None` - The event doesn't occur on this date (e.g. circumpolar)
+///
+/// # Examples
+///
+/// ```
+/// use solunatus::prelude::*;
+/// use solunatus::astro::planets::{planet_event_time, Planet, PlanetEvent};
+/// use chrono::Local;
+/// use chrono_tz::America::New_York;
+///
+/// let location = Location::new(40.7128, -74.0060).unwrap();
+/// let now = Local::now().with_timezone(&New_York);
+///
+/// if let Some(rise) = planet_event_time(Planet::Jupiter, &location, &now, PlanetEvent::Rise) {
+///     println!("Jupiter rises at {}", rise.format("%H:%M"));
+/// }
+/// ```
+pub fn planet_event_time<T: TimeZone>(
+    planet: Planet,
+    location: &Location,
+    date: &DateTime<T>,
+    event: PlanetEvent,
+) -> Option<DateTime<T>> {
+    let seek_rising = event == PlanetEvent::Rise;
+
+    let tz = date.timezone();
+    let start_naive = date.date_naive().and_hms_opt(0, 0, 0)?;
+    let start = match tz.from_local_datetime(&start_naive) {
+        chrono::LocalResult::Single(dt) => dt,
+        chrono::LocalResult::Ambiguous(early, _) => early,
+        chrono::LocalResult::None => tz
+            .from_local_datetime(&(start_naive + Duration::hours(1)))
+            .earliest()?,
+    };
+    let end = start.clone() + Duration::hours(24);
+
+    let step = Duration::minutes(10);
+    let mut prev_dt = start.clone();
+    let mut prev_alt = planet_position(planet, location, &prev_dt).altitude - RISE_SET_ALTITUDE;
+
+    loop {
+        let current = prev_dt.clone().checked_add_signed(step)?;
+        if current > end {
+            break;
+        }
+        let alt = planet_position(planet, location, &current).altitude - RISE_SET_ALTITUDE;
+        let crossing = if seek_rising {
+            prev_alt <= 0.0 && alt >= 0.0
+        } else {
+            prev_alt >= 0.0 && alt <= 0.0
+        };
+
+        if crossing {
+            return Some(refine_planet_crossing(
+                planet,
+                location,
+                prev_dt,
+                current,
+                seek_rising,
+            ));
+        }
+
+        prev_dt = current;
+        prev_alt = alt;
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    /// The Jupiter–Saturn great conjunction: on 2020-12-21 the two planets
+    /// were separated by only ~0.1°. The truncated theory should agree on
+    /// their geocentric ecliptic longitudes to well within half a degree.
+    #[test]
+    fn great_conjunction_2020() {
+        let dt = Utc.with_ymd_and_hms(2020, 12, 21, 18, 0, 0).unwrap();
+        let jd = julian_day(&dt);
+
+        let (jup_lon, _, _, _, _) = geocentric_ecliptic(Planet::Jupiter, jd);
+        let (sat_lon, _, _, _, _) = geocentric_ecliptic(Planet::Saturn, jd);
+
+        let separation = normalize_degrees_signed(jup_lon - sat_lon).abs();
+        assert!(
+            separation < 0.5,
+            "Jupiter–Saturn separation {separation:.3}° too large for the great conjunction"
+        );
+    }
+
+    /// Venus never strays more than ~47° from the sun.
+    #[test]
+    fn venus_elongation_bounded() {
+        let location = Location::new(40.7128, -74.0060).unwrap();
+        for month in 1..=12 {
+            let dt = Utc.with_ymd_and_hms(2025, month, 15, 0, 0, 0).unwrap();
+            let pos = planet_position(Planet::Venus, &location, &dt);
+            assert!(
+                pos.elongation <= 48.5,
+                "Venus elongation {:.1}° in month {month} exceeds maximum",
+                pos.elongation
+            );
+        }
+    }
+
+    /// Mercury never strays more than ~28° from the sun.
+    #[test]
+    fn mercury_elongation_bounded() {
+        let location = Location::new(40.7128, -74.0060).unwrap();
+        for month in 1..=12 {
+            let dt = Utc.with_ymd_and_hms(2025, month, 15, 0, 0, 0).unwrap();
+            let pos = planet_position(Planet::Mercury, &location, &dt);
+            assert!(
+                pos.elongation <= 28.5,
+                "Mercury elongation {:.1}° in month {month} exceeds maximum",
+                pos.elongation
+            );
+        }
+    }
+
+    #[test]
+    fn geocentric_distances_within_physical_bounds() {
+        let location = Location::new(0.0, 0.0).unwrap();
+        let ranges = [
+            (Planet::Mercury, 0.50, 1.50),
+            (Planet::Venus, 0.25, 1.75),
+            (Planet::Mars, 0.36, 2.70),
+            (Planet::Jupiter, 3.9, 6.5),
+            (Planet::Saturn, 7.9, 11.1),
+            (Planet::Uranus, 17.0, 21.2),
+            (Planet::Neptune, 28.7, 31.5),
+        ];
+        for month in [1u32, 4, 7, 10] {
+            let dt = Utc.with_ymd_and_hms(2026, month, 1, 0, 0, 0).unwrap();
+            for (planet, min_au, max_au) in ranges {
+                let pos = planet_position(planet, &location, &dt);
+                assert!(
+                    (min_au..=max_au).contains(&pos.distance_au),
+                    "{} distance {:.2} AU outside [{min_au}, {max_au}]",
+                    planet.name(),
+                    pos.distance_au
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rise_event_crosses_horizon_threshold() {
+        use chrono_tz::America::New_York;
+
+        let location = Location::new(40.7128, -74.0060).unwrap();
+        let date = Utc
+            .with_ymd_and_hms(2026, 3, 15, 12, 0, 0)
+            .unwrap()
+            .with_timezone(&New_York);
+
+        for planet in Planet::ALL {
+            let rise = planet_event_time(planet, &location, &date, PlanetEvent::Rise);
+            let set = planet_event_time(planet, &location, &date, PlanetEvent::Set);
+            // At 40°N every planet rises and sets daily.
+            let rise = rise.unwrap_or_else(|| panic!("{} should rise", planet.name()));
+            let set = set.unwrap_or_else(|| panic!("{} should set", planet.name()));
+
+            let alt_at_rise = planet_position(planet, &location, &rise).altitude;
+            assert!(
+                (alt_at_rise - RISE_SET_ALTITUDE).abs() < 0.05,
+                "{} altitude at rise = {alt_at_rise:.3}°, expected ≈ {RISE_SET_ALTITUDE}",
+                planet.name()
+            );
+
+            let alt_at_set = planet_position(planet, &location, &set).altitude;
+            assert!(
+                (alt_at_set - RISE_SET_ALTITUDE).abs() < 0.05,
+                "{} altitude at set = {alt_at_set:.3}°",
+                planet.name()
+            );
+        }
+    }
+}

--- a/src/astro/seasons.rs
+++ b/src/astro/seasons.rs
@@ -1,0 +1,261 @@
+//! Equinox and solstice calculations.
+//!
+//! Computes the instants of the equinoxes and solstices using the algorithm
+//! from Jean Meeus, "Astronomical Algorithms", 2nd Edition, Chapter 27
+//! (mean-event polynomials plus 24 periodic correction terms).
+//!
+//! # Accuracy
+//!
+//! Within the years 1000–3000 the underlying algorithm is accurate to well
+//! under a minute. Results are converted from Terrestrial Time to UTC with a
+//! ΔT estimate that is precise for 1986–2150 and approximate outside that
+//! range.
+
+use super::moon::jd_to_datetime;
+use super::{DEG_TO_RAD, julian_century};
+use chrono::{DateTime, Datelike, TimeZone, Utc};
+
+/// The four seasonal events of the tropical year.
+///
+/// Named by month rather than season so the terms apply in both hemispheres.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeasonalEventKind {
+    /// March equinox (sun crosses the celestial equator northward)
+    MarchEquinox,
+    /// June solstice (sun at maximum northern declination)
+    JuneSolstice,
+    /// September equinox (sun crosses the celestial equator southward)
+    SeptemberEquinox,
+    /// December solstice (sun at maximum southern declination)
+    DecemberSolstice,
+}
+
+impl SeasonalEventKind {
+    /// Human-readable name (e.g. "March Equinox").
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        match self {
+            SeasonalEventKind::MarchEquinox => "March Equinox",
+            SeasonalEventKind::JuneSolstice => "June Solstice",
+            SeasonalEventKind::SeptemberEquinox => "September Equinox",
+            SeasonalEventKind::DecemberSolstice => "December Solstice",
+        }
+    }
+}
+
+/// A seasonal event (equinox or solstice) with its UTC instant.
+#[derive(Debug, Clone)]
+pub struct SeasonalEvent {
+    /// Which equinox or solstice this is
+    pub kind: SeasonalEventKind,
+    /// UTC time of the event
+    pub datetime: DateTime<Utc>,
+}
+
+/// Periodic correction terms from Meeus Table 27.C: (A, B, C) with the
+/// contribution A·cos(B + C·T) in units of 0.00001 day.
+const PERIODIC_TERMS: &[(f64, f64, f64)] = &[
+    (485.0, 324.96, 1934.136),
+    (203.0, 337.23, 32964.467),
+    (199.0, 342.08, 20.186),
+    (182.0, 27.85, 445267.112),
+    (156.0, 73.14, 45036.886),
+    (136.0, 171.52, 22518.443),
+    (77.0, 222.54, 65928.934),
+    (74.0, 296.72, 3034.906),
+    (70.0, 243.58, 9037.513),
+    (58.0, 119.81, 33718.147),
+    (52.0, 297.17, 150.678),
+    (50.0, 21.02, 2281.226),
+    (45.0, 247.54, 29929.562),
+    (44.0, 325.15, 31555.956),
+    (29.0, 60.93, 4443.417),
+    (18.0, 155.12, 67555.328),
+    (17.0, 288.79, 4562.452),
+    (16.0, 198.04, 62894.029),
+    (14.0, 199.76, 31436.921),
+    (12.0, 95.39, 14577.848),
+    (12.0, 287.11, 31931.756),
+    (12.0, 320.81, 34777.259),
+    (9.0, 227.73, 1222.114),
+    (8.0, 15.45, 16859.074),
+];
+
+/// Mean event time JDE0 (Meeus Tables 27.A/27.B).
+fn mean_event_jde(kind: SeasonalEventKind, year: i32) -> f64 {
+    if year >= 1000 {
+        // Table 27.B, years 1000 to 3000; Y = (year - 2000) / 1000
+        let y = f64::from(year - 2000) / 1000.0;
+        match kind {
+            SeasonalEventKind::MarchEquinox => {
+                2451623.80984 + y * (365242.37404 + y * (0.05169 + y * (-0.00411 - y * 0.00057)))
+            }
+            SeasonalEventKind::JuneSolstice => {
+                2451716.56767 + y * (365241.62603 + y * (0.00325 + y * (0.00888 - y * 0.00030)))
+            }
+            SeasonalEventKind::SeptemberEquinox => {
+                2451810.21715 + y * (365242.01767 + y * (-0.11575 + y * (0.00337 + y * 0.00078)))
+            }
+            SeasonalEventKind::DecemberSolstice => {
+                2451900.05952 + y * (365242.74049 + y * (-0.06223 + y * (-0.00823 + y * 0.00032)))
+            }
+        }
+    } else {
+        // Table 27.A, years -1000 to +1000; Y = year / 1000
+        let y = f64::from(year) / 1000.0;
+        match kind {
+            SeasonalEventKind::MarchEquinox => {
+                1721139.29189 + y * (365242.13740 + y * (0.06134 + y * (0.00111 - y * 0.00071)))
+            }
+            SeasonalEventKind::JuneSolstice => {
+                1721233.25401 + y * (365241.72562 + y * (-0.05323 + y * (0.00907 + y * 0.00025)))
+            }
+            SeasonalEventKind::SeptemberEquinox => {
+                1721325.70455 + y * (365242.49558 + y * (-0.11677 + y * (-0.00297 + y * 0.00074)))
+            }
+            SeasonalEventKind::DecemberSolstice => {
+                1721414.39987 + y * (365242.88257 + y * (-0.00769 + y * (-0.00933 - y * 0.00006)))
+            }
+        }
+    }
+}
+
+/// Estimate ΔT = TT − UT in seconds for a given year.
+///
+/// Uses the Espenak–Meeus polynomial expressions for 1986–2150 and the
+/// long-term parabolic fit elsewhere.
+fn delta_t_seconds(year: i32) -> f64 {
+    let y = f64::from(year);
+    if (1986..2005).contains(&year) {
+        let t = y - 2000.0;
+        63.86
+            + t * (0.3345
+                + t * (-0.060374 + t * (0.0017275 + t * (0.000651814 + t * 0.00002373599))))
+    } else if (2005..2050).contains(&year) {
+        let t = y - 2000.0;
+        62.92 + t * (0.32217 + t * 0.005589)
+    } else if (2050..=2150).contains(&year) {
+        let u = (y - 1820.0) / 100.0;
+        -20.0 + 32.0 * u * u - 0.5628 * (2150.0 - y)
+    } else {
+        let u = (y - 1820.0) / 100.0;
+        -20.0 + 32.0 * u * u
+    }
+}
+
+/// Julian Ephemeris Day (TT) of a seasonal event.
+fn seasonal_event_jde(kind: SeasonalEventKind, year: i32) -> f64 {
+    let jde0 = mean_event_jde(kind, year);
+    let t = julian_century(jde0);
+    let w = (35999.373 * t - 2.47) * DEG_TO_RAD;
+    let delta_lambda = 1.0 + 0.0334 * w.cos() + 0.0007 * (2.0 * w).cos();
+
+    let s: f64 = PERIODIC_TERMS
+        .iter()
+        .map(|&(a, b, c)| a * ((b + c * t) * DEG_TO_RAD).cos())
+        .sum();
+
+    jde0 + 0.00001 * s / delta_lambda
+}
+
+/// Calculate all four seasonal events (equinoxes and solstices) for a year.
+///
+/// Returns the events in chronological order with UTC times.
+///
+/// # Examples
+///
+/// ```
+/// use solunatus::astro::seasons::seasonal_events;
+///
+/// for event in seasonal_events(2026) {
+///     println!("{}: {}", event.kind.name(), event.datetime.format("%Y-%m-%d %H:%M UTC"));
+/// }
+/// ```
+#[must_use]
+pub fn seasonal_events(year: i32) -> Vec<SeasonalEvent> {
+    [
+        SeasonalEventKind::MarchEquinox,
+        SeasonalEventKind::JuneSolstice,
+        SeasonalEventKind::SeptemberEquinox,
+        SeasonalEventKind::DecemberSolstice,
+    ]
+    .into_iter()
+    .filter_map(|kind| {
+        let jde = seasonal_event_jde(kind, year);
+        let jd_utc = jde - delta_t_seconds(year) / 86400.0;
+        jd_to_datetime(jd_utc).map(|datetime| SeasonalEvent { kind, datetime })
+    })
+    .collect()
+}
+
+/// Find the next `count` seasonal events strictly after a given time.
+///
+/// # Examples
+///
+/// ```
+/// use solunatus::astro::seasons::next_seasonal_events;
+/// use chrono::Utc;
+///
+/// let upcoming = next_seasonal_events(&Utc::now(), 2);
+/// assert_eq!(upcoming.len(), 2);
+/// ```
+#[must_use]
+pub fn next_seasonal_events<T: TimeZone>(after: &DateTime<T>, count: usize) -> Vec<SeasonalEvent> {
+    let after_utc = after.with_timezone(&Utc);
+    let year = after_utc.year();
+
+    let mut events: Vec<SeasonalEvent> = (year..=year + 1)
+        .flat_map(seasonal_events)
+        .filter(|event| event.datetime > after_utc)
+        .collect();
+    events.sort_by_key(|event| event.datetime);
+    events.truncate(count);
+    events
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Meeus Example 27.a: the June solstice of 1962 occurs at
+    /// JDE 2437837.39245 (1962 June 21, 21:24:42 TT).
+    #[test]
+    fn meeus_example_27a_june_solstice_1962() {
+        let jde = seasonal_event_jde(SeasonalEventKind::JuneSolstice, 1962);
+        assert!(
+            (jde - 2437837.39245).abs() < 0.0005,
+            "JDE {jde} differs from Meeus reference 2437837.39245"
+        );
+    }
+
+    #[test]
+    fn seasonal_events_are_chronological_and_in_expected_months() {
+        let events = seasonal_events(2026);
+        assert_eq!(events.len(), 4);
+        assert!(
+            events
+                .windows(2)
+                .all(|pair| pair[0].datetime < pair[1].datetime)
+        );
+
+        let months: Vec<u32> = events.iter().map(|e| e.datetime.month()).collect();
+        assert_eq!(months, vec![3, 6, 9, 12]);
+
+        // Equinoxes/solstices always fall on days 19-23 of their month.
+        for event in &events {
+            let day = event.datetime.day();
+            assert!((19..=23).contains(&day), "{:?} on day {day}", event.kind);
+        }
+    }
+
+    #[test]
+    fn next_seasonal_events_crosses_year_boundary() {
+        let after = Utc.with_ymd_and_hms(2026, 11, 1, 0, 0, 0).unwrap();
+        let upcoming = next_seasonal_events(&after, 2);
+        assert_eq!(upcoming.len(), 2);
+        assert_eq!(upcoming[0].kind, SeasonalEventKind::DecemberSolstice);
+        assert_eq!(upcoming[1].kind, SeasonalEventKind::MarchEquinox);
+        assert_eq!(upcoming[0].datetime.year(), 2026);
+        assert_eq!(upcoming[1].datetime.year(), 2027);
+    }
+}

--- a/src/astro/sun.rs
+++ b/src/astro/sun.rs
@@ -23,6 +23,7 @@ use chrono::{DateTime, Duration, TimeZone};
 /// - Civil twilight: -6°
 /// - Nautical twilight: -12°
 /// - Astronomical twilight: -18°
+/// - Golden hour boundaries: -4° and +6° (photography convention)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SolarEvent {
     /// Sunrise (top edge of sun appears on horizon)
@@ -43,6 +44,16 @@ pub enum SolarEvent {
     AstronomicalDawn,
     /// Astronomical dusk (sun 18° below horizon, evening)
     AstronomicalDusk,
+    /// Morning golden hour start (sun 4° below horizon, rising).
+    /// Also marks the end of the morning blue hour.
+    GoldenDawnStart,
+    /// Morning golden hour end (sun 6° above horizon, rising)
+    GoldenDawnEnd,
+    /// Evening golden hour start (sun 6° above horizon, setting)
+    GoldenDuskStart,
+    /// Evening golden hour end (sun 4° below horizon, setting).
+    /// Also marks the start of the evening blue hour.
+    GoldenDuskEnd,
 }
 
 impl SolarEvent {
@@ -55,6 +66,8 @@ impl SolarEvent {
             SolarEvent::CivilDawn | SolarEvent::CivilDusk => -6.0,
             SolarEvent::NauticalDawn | SolarEvent::NauticalDusk => -12.0,
             SolarEvent::AstronomicalDawn | SolarEvent::AstronomicalDusk => -18.0,
+            SolarEvent::GoldenDawnStart | SolarEvent::GoldenDuskEnd => -4.0,
+            SolarEvent::GoldenDawnEnd | SolarEvent::GoldenDuskStart => 6.0,
             SolarEvent::SolarNoon => 90.0, // Not used for altitude calculation
         }
     }
@@ -284,6 +297,8 @@ pub fn solar_event_time<T: TimeZone>(
             | SolarEvent::CivilDawn
             | SolarEvent::NauticalDawn
             | SolarEvent::AstronomicalDawn
+            | SolarEvent::GoldenDawnStart
+            | SolarEvent::GoldenDawnEnd
     );
 
     let offset = if is_rising {
@@ -297,6 +312,76 @@ pub fn solar_event_time<T: TimeZone>(
         + Duration::seconds((offset * 60.0) as i64);
 
     Some(event_utc.with_timezone(&date.timezone()))
+}
+
+/// Photography lighting periods (golden hour and blue hour) for one day.
+///
+/// Golden hour spans sun altitudes from -4° to +6° (soft, warm light).
+/// Blue hour spans -6° to -4°, i.e. from civil dawn/dusk to the golden hour
+/// boundary (deep blue sky before sunrise / after sunset).
+///
+/// Each period is `None` when its boundary altitudes are not crossed on the
+/// given date (polar day/night and high-latitude edge cases).
+#[derive(Debug, Clone)]
+pub struct PhotoPeriods<T: TimeZone> {
+    /// Morning blue hour (civil dawn → sun at -4°, rising)
+    pub morning_blue: Option<(DateTime<T>, DateTime<T>)>,
+    /// Morning golden hour (sun at -4° → +6°, rising)
+    pub morning_golden: Option<(DateTime<T>, DateTime<T>)>,
+    /// Evening golden hour (sun at +6° → -4°, setting)
+    pub evening_golden: Option<(DateTime<T>, DateTime<T>)>,
+    /// Evening blue hour (sun at -4°, setting → civil dusk)
+    pub evening_blue: Option<(DateTime<T>, DateTime<T>)>,
+}
+
+/// Calculate the golden hour and blue hour periods for a given location and date.
+///
+/// # Examples
+///
+/// ```
+/// use solunatus::prelude::*;
+/// use solunatus::astro::sun::photo_periods;
+/// use chrono::Local;
+/// use chrono_tz::America::New_York;
+///
+/// let location = Location::new(40.7128, -74.0060).unwrap();
+/// let now = Local::now().with_timezone(&New_York);
+/// let periods = photo_periods(&location, &now);
+///
+/// if let Some((start, end)) = periods.evening_golden {
+///     println!("Golden hour: {} – {}", start.format("%H:%M"), end.format("%H:%M"));
+/// }
+/// ```
+#[must_use]
+pub fn photo_periods<T: TimeZone>(location: &Location, date: &DateTime<T>) -> PhotoPeriods<T> {
+    fn pair<T: TimeZone>(
+        start: Option<DateTime<T>>,
+        end: Option<DateTime<T>>,
+    ) -> Option<(DateTime<T>, DateTime<T>)> {
+        match (start, end) {
+            (Some(s), Some(e)) if s <= e => Some((s, e)),
+            _ => None,
+        }
+    }
+
+    PhotoPeriods {
+        morning_blue: pair(
+            solar_event_time(location, date, SolarEvent::CivilDawn),
+            solar_event_time(location, date, SolarEvent::GoldenDawnStart),
+        ),
+        morning_golden: pair(
+            solar_event_time(location, date, SolarEvent::GoldenDawnStart),
+            solar_event_time(location, date, SolarEvent::GoldenDawnEnd),
+        ),
+        evening_golden: pair(
+            solar_event_time(location, date, SolarEvent::GoldenDuskStart),
+            solar_event_time(location, date, SolarEvent::GoldenDuskEnd),
+        ),
+        evening_blue: pair(
+            solar_event_time(location, date, SolarEvent::GoldenDuskEnd),
+            solar_event_time(location, date, SolarEvent::CivilDusk),
+        ),
+    }
 }
 
 /// Calculate the solar position (altitude and azimuth) at a specific time.
@@ -375,6 +460,65 @@ pub fn solar_position<T: TimeZone>(location: &Location, dt: &DateTime<T>) -> Sol
 mod tests {
     use super::*;
     use chrono::Utc;
+
+    #[test]
+    fn golden_hour_events_bracket_sunrise() {
+        use chrono_tz::America::New_York;
+
+        let location = Location::new(40.7128, -74.0060).unwrap();
+        let date = Utc
+            .with_ymd_and_hms(2025, 6, 21, 12, 0, 0)
+            .unwrap()
+            .with_timezone(&New_York);
+
+        let civil_dawn = solar_event_time(&location, &date, SolarEvent::CivilDawn).unwrap();
+        let golden_start = solar_event_time(&location, &date, SolarEvent::GoldenDawnStart).unwrap();
+        let sunrise = solar_event_time(&location, &date, SolarEvent::Sunrise).unwrap();
+        let golden_end = solar_event_time(&location, &date, SolarEvent::GoldenDawnEnd).unwrap();
+
+        // Sun ascends through -6°, -4°, -0.833°, +6° in order.
+        assert!(civil_dawn < golden_start);
+        assert!(golden_start < sunrise);
+        assert!(sunrise < golden_end);
+
+        let dusk_start = solar_event_time(&location, &date, SolarEvent::GoldenDuskStart).unwrap();
+        let sunset = solar_event_time(&location, &date, SolarEvent::Sunset).unwrap();
+        let dusk_end = solar_event_time(&location, &date, SolarEvent::GoldenDuskEnd).unwrap();
+        let civil_dusk = solar_event_time(&location, &date, SolarEvent::CivilDusk).unwrap();
+        assert!(dusk_start < sunset);
+        assert!(sunset < dusk_end);
+        assert!(dusk_end < civil_dusk);
+    }
+
+    #[test]
+    fn photo_periods_are_contiguous() {
+        use chrono_tz::America::New_York;
+
+        let location = Location::new(40.7128, -74.0060).unwrap();
+        let date = Utc
+            .with_ymd_and_hms(2025, 6, 21, 12, 0, 0)
+            .unwrap()
+            .with_timezone(&New_York);
+
+        let periods = photo_periods(&location, &date);
+        let (blue_start, blue_end) = periods.morning_blue.expect("morning blue hour");
+        let (golden_start, golden_end) = periods.morning_golden.expect("morning golden hour");
+        assert_eq!(
+            blue_end, golden_start,
+            "blue hour should end as golden hour begins"
+        );
+        assert!(blue_start < blue_end);
+        assert!(golden_start < golden_end);
+
+        let (eg_start, eg_end) = periods.evening_golden.expect("evening golden hour");
+        let (eb_start, eb_end) = periods.evening_blue.expect("evening blue hour");
+        assert_eq!(
+            eg_end, eb_start,
+            "evening golden hour should end as blue hour begins"
+        );
+        assert!(eg_start < eg_end);
+        assert!(eb_start < eb_end);
+    }
 
     #[test]
     fn test_equation_of_time() {

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -28,6 +28,8 @@ pub enum CalendarFormat {
     Html,
     /// JSON format for programmatic access
     Json,
+    /// iCalendar format (RFC 5545) for import into calendar applications
+    Ics,
 }
 
 #[derive(Debug)]
@@ -157,6 +159,9 @@ pub fn generate_calendar(
             location, timezone, city_name, start, end, &records,
         )),
         CalendarFormat::Json => render_json(location, timezone, city_name, start, end, &records),
+        CalendarFormat::Ics => Ok(render_ics(
+            location, timezone, city_name, start, end, &records,
+        )),
     }
 }
 
@@ -471,6 +476,170 @@ fn render_html(
     html
 }
 
+/// Escape text per RFC 5545 (backslash, semicolon, comma, newline).
+fn escape_ics(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace(';', "\\;")
+        .replace(',', "\\,")
+        .replace('\n', "\\n")
+}
+
+/// Fold a content line at 75 octets per RFC 5545 (continuation lines start
+/// with a single space). Folds on character boundaries.
+fn fold_ics_line(line: &str, out: &mut String) {
+    const LIMIT: usize = 75;
+    let mut budget = LIMIT;
+    let mut len = 0usize;
+
+    for ch in line.chars() {
+        let ch_len = ch.len_utf8();
+        if len + ch_len > budget {
+            out.push_str("\r\n ");
+            budget = LIMIT - 1; // continuation lines lose one octet to the leading space
+            len = 0;
+        }
+        out.push(ch);
+        len += ch_len;
+    }
+    out.push_str("\r\n");
+}
+
+fn push_ics_event(
+    out: &mut String,
+    dtstamp: &str,
+    uid_suffix: &str,
+    event_utc: chrono::DateTime<Utc>,
+    summary: &str,
+) {
+    fold_ics_line("BEGIN:VEVENT", out);
+    fold_ics_line(
+        &format!(
+            "UID:{}-{}@solunatus",
+            event_utc.format("%Y%m%dT%H%M%SZ"),
+            uid_suffix
+        ),
+        out,
+    );
+    fold_ics_line(&format!("DTSTAMP:{}", dtstamp), out);
+    fold_ics_line(
+        &format!("DTSTART:{}", event_utc.format("%Y%m%dT%H%M%SZ")),
+        out,
+    );
+    fold_ics_line(&format!("SUMMARY:{}", escape_ics(summary)), out);
+    fold_ics_line("END:VEVENT", out);
+}
+
+fn render_ics(
+    location: &Location,
+    timezone: &Tz,
+    city_name: Option<&str>,
+    start: NaiveDate,
+    end: NaiveDate,
+    records: &[DailyRecord],
+) -> String {
+    let dtstamp = Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let place = city_name.map_or_else(
+        || {
+            format!(
+                "{}, {}",
+                format_lat(location.latitude.value()),
+                format_lon(location.longitude.value())
+            )
+        },
+        ToString::to_string,
+    );
+
+    let mut out = String::new();
+    fold_ics_line("BEGIN:VCALENDAR", &mut out);
+    fold_ics_line("VERSION:2.0", &mut out);
+    fold_ics_line(
+        &format!(
+            "PRODID:-//Solunatus//solunatus {}//EN",
+            env!("CARGO_PKG_VERSION")
+        ),
+        &mut out,
+    );
+    fold_ics_line("CALSCALE:GREGORIAN", &mut out);
+    fold_ics_line("METHOD:PUBLISH", &mut out);
+    fold_ics_line(
+        &format!("X-WR-CALNAME:Sun & Moon — {}", escape_ics(&place)),
+        &mut out,
+    );
+
+    type DailyEventAccessor = fn(&DailyRecord) -> Option<chrono::DateTime<Tz>>;
+    let daily_events: [(&str, DailyEventAccessor); 4] = [
+        ("Sunrise 🌅", |r| r.sunrise),
+        ("Sunset 🌇", |r| r.sunset),
+        ("Moonrise 🌕", |r| r.moonrise),
+        ("Moonset 🌑", |r| r.moonset),
+    ];
+
+    let uid_coords = format!(
+        "{:.2}{:.2}",
+        location.latitude.value(),
+        location.longitude.value()
+    );
+
+    for record in records {
+        for (summary, accessor) in daily_events {
+            if let Some(event_time) = accessor(record) {
+                let slug = summary
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("event")
+                    .to_lowercase();
+                push_ics_event(
+                    &mut out,
+                    &dtstamp,
+                    &format!("{}-{}", slug, uid_coords),
+                    event_time.with_timezone(&Utc),
+                    summary,
+                );
+            }
+        }
+    }
+
+    // Quarter lunar phases that fall (in local time) within the range.
+    let mut cursor = start.with_day(1).unwrap_or(start);
+    while cursor <= end {
+        for phase in moon::lunar_phases(cursor.year(), cursor.month()) {
+            let local_date = phase.datetime.with_timezone(timezone).date_naive();
+            if local_date < start || local_date > end {
+                continue;
+            }
+            let summary = match phase.phase_type {
+                moon::LunarPhaseType::NewMoon => "New Moon 🌑".to_string(),
+                moon::LunarPhaseType::FirstQuarter => "First Quarter 🌓".to_string(),
+                moon::LunarPhaseType::FullMoon => {
+                    if moon::is_supermoon(&phase) {
+                        "Full Moon (Supermoon) 🌕".to_string()
+                    } else {
+                        "Full Moon 🌕".to_string()
+                    }
+                }
+                moon::LunarPhaseType::LastQuarter => "Last Quarter 🌗".to_string(),
+            };
+            push_ics_event(&mut out, &dtstamp, "phase", phase.datetime, &summary);
+        }
+
+        cursor = if cursor.month() == 12 {
+            match NaiveDate::from_ymd_opt(cursor.year() + 1, 1, 1) {
+                Some(next) => next,
+                None => break,
+            }
+        } else {
+            match NaiveDate::from_ymd_opt(cursor.year(), cursor.month() + 1, 1) {
+                Some(next) => next,
+                None => break,
+            }
+        };
+    }
+
+    fold_ics_line("END:VCALENDAR", &mut out);
+    out
+}
+
 fn format_time(dt: chrono::DateTime<Tz>) -> String {
     dt.format("%H:%M").to_string()
 }
@@ -537,6 +706,52 @@ mod tests {
     use super::*;
     use crate::astro::moon;
     use chrono_tz::America::New_York;
+
+    #[test]
+    fn ics_calendar_is_well_formed() {
+        let location = Location::new(40.7128, -74.0060).unwrap();
+        let tz = New_York;
+        let start = NaiveDate::from_ymd_opt(2025, 10, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2025, 10, 31).unwrap();
+
+        let ics = generate_calendar(
+            &location,
+            &tz,
+            Some("New York"),
+            start,
+            end,
+            CalendarFormat::Ics,
+        )
+        .unwrap();
+
+        assert!(ics.starts_with("BEGIN:VCALENDAR\r\n"));
+        assert!(ics.ends_with("END:VCALENDAR\r\n"));
+        assert!(ics.contains("VERSION:2.0\r\n"));
+
+        let begins = ics.matches("BEGIN:VEVENT").count();
+        let ends = ics.matches("END:VEVENT").count();
+        assert_eq!(begins, ends, "unbalanced VEVENT blocks");
+        // 31 days × up to 4 daily events, minus the occasional missing
+        // moonrise/moonset, plus 4-5 quarter phases.
+        assert!(begins >= 120, "only {begins} events generated");
+
+        // Every event needs UID, DTSTAMP, DTSTART, SUMMARY.
+        for field in ["UID:", "DTSTAMP:", "DTSTART:", "SUMMARY:"] {
+            assert_eq!(ics.matches(field).count(), begins, "missing {field} fields");
+        }
+
+        // Full moon of Oct 2025 (Oct 7, 03:47 UTC) must be present.
+        assert!(
+            ics.contains("DTSTART:20251007T03"),
+            "full moon event missing"
+        );
+
+        // RFC 5545: all lines CRLF-terminated and at most 75 octets.
+        for line in ics.split("\r\n") {
+            assert!(!line.contains('\n'), "bare LF found");
+            assert!(line.len() <= 75, "line exceeds 75 octets: {line}");
+        }
+    }
 
     /// The calendar must report the same moonrise/moonset as the canonical
     /// `lunar_event_time` algorithm. This guards against reintroducing a separate

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -600,9 +600,24 @@ fn render_ics(
         }
     }
 
-    // Quarter lunar phases that fall (in local time) within the range.
-    let mut cursor = start.with_day(1).unwrap_or(start);
-    while cursor <= end {
+    // Quarter lunar phases that fall (in local time) within the range. Phases
+    // are tabulated by UTC month, and one near a month boundary can have a
+    // local date in the neighboring month, so scan one UTC month past each
+    // end of the range and let the local-date filter decide.
+    let first_month = start.with_day(1).unwrap_or(start);
+    let mut cursor = if first_month.month() == 1 {
+        NaiveDate::from_ymd_opt(first_month.year() - 1, 12, 1)
+    } else {
+        NaiveDate::from_ymd_opt(first_month.year(), first_month.month() - 1, 1)
+    }
+    .unwrap_or(first_month);
+    let scan_end = if end.month() == 12 {
+        NaiveDate::from_ymd_opt(end.year() + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(end.year(), end.month() + 1, 1)
+    }
+    .unwrap_or(end);
+    while cursor <= scan_end {
         for phase in moon::lunar_phases(cursor.year(), cursor.month()) {
             let local_date = phase.datetime.with_timezone(timezone).date_naive();
             if local_date < start || local_date > end {
@@ -751,6 +766,32 @@ mod tests {
             assert!(!line.contains('\n'), "bare LF found");
             assert!(line.len() <= 75, "line exceeds 75 octets: {line}");
         }
+    }
+
+    /// A phase early in a UTC month can fall on the last local day of the
+    /// previous month: the 2026-12-01 06:14 UTC last quarter is 2026-11-30 in
+    /// Los Angeles, so a November export there must still include it.
+    #[test]
+    fn ics_includes_phases_across_utc_month_boundary() {
+        let location = Location::new(34.0522, -118.2437).unwrap();
+        let tz = chrono_tz::America::Los_Angeles;
+        let start = NaiveDate::from_ymd_opt(2026, 11, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2026, 11, 30).unwrap();
+
+        let ics = generate_calendar(
+            &location,
+            &tz,
+            Some("Los Angeles"),
+            start,
+            end,
+            CalendarFormat::Ics,
+        )
+        .unwrap();
+
+        assert!(
+            ics.contains("DTSTART:20261201T06"),
+            "last quarter on the local Nov 30 (Dec 1 UTC) missing from November export"
+        );
     }
 
     /// The calendar must report the same moonrise/moonset as the canonical

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,41 @@ use std::path::PathBuf;
 pub enum CalendarFormatArg {
     Html,
     Json,
+    Ics,
+}
+
+/// Events queryable via `--next` (kebab-case on the command line,
+/// e.g. `--next solar-noon`).
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum NextEventArg {
+    Sunrise,
+    Sunset,
+    SolarNoon,
+    CivilDawn,
+    CivilDusk,
+    NauticalDawn,
+    NauticalDusk,
+    AstronomicalDawn,
+    AstronomicalDusk,
+    GoldenDawnStart,
+    GoldenDawnEnd,
+    GoldenDuskStart,
+    GoldenDuskEnd,
+    Moonrise,
+    Moonset,
+}
+
+/// Output format for `--next`.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum TimeFormatArg {
+    /// RFC 3339 with local offset (e.g. 2026-06-09T20:19:44-04:00)
+    Iso,
+    /// Unix epoch seconds
+    Unix,
+    /// Local time without offset (e.g. 2026-06-09 20:19:44)
+    Local,
+    /// Local time plus a countdown (e.g. ... (08:19:44 from now))
+    Human,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -42,7 +77,7 @@ pub struct Args {
     #[arg(long)]
     pub calendar: bool,
 
-    /// Calendar output format (html or json)
+    /// Calendar output format (html, json, or ics)
     #[arg(long, default_value = "html", value_enum)]
     pub calendar_format: CalendarFormatArg,
 
@@ -57,6 +92,15 @@ pub struct Args {
     /// Path to write the generated calendar (stdout when omitted)
     #[arg(long, requires = "calendar")]
     pub calendar_output: Option<PathBuf>,
+
+    /// Print the next occurrence of an event and exit (for scripting).
+    /// Searches forward from now, or from noon of --date when given.
+    #[arg(long, value_enum)]
+    pub next: Option<NextEventArg>,
+
+    /// Output format for --next
+    #[arg(long, value_enum, default_value = "iso", requires = "next")]
+    pub format: TimeFormatArg,
 
     /// Force watch mode (live updates)
     #[arg(long)]
@@ -98,6 +142,14 @@ pub struct Args {
     #[cfg(feature = "usno-validation")]
     #[arg(long)]
     pub validate: bool,
+
+    /// Generate shell completions to stdout and exit
+    #[arg(long, value_enum, value_name = "SHELL")]
+    pub completions: Option<clap_complete::Shell>,
+
+    /// Generate a man page (roff format) to stdout and exit
+    #[arg(long)]
+    pub manpage: bool,
 }
 
 impl Args {

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,9 @@ pub struct WatchPreferences {
     /// Show lunar phases section (default: true)
     #[serde(default = "default_true")]
     pub show_lunar_phases: bool,
+    /// Show planets section (Mercury through Neptune) (default: true)
+    #[serde(default = "default_true")]
+    pub show_planets: bool,
     /// Show AI insights section (default: false)
     #[cfg(feature = "ai-insights")]
     #[serde(default = "default_false")]
@@ -168,6 +171,7 @@ impl Default for WatchPreferences {
             show_positions: true,
             show_moon: true,
             show_lunar_phases: true,
+            show_planets: true,
             #[cfg(feature = "ai-insights")]
             show_ai_insights: false,
             night_mode: false,

--- a/src/events.rs
+++ b/src/events.rs
@@ -26,8 +26,16 @@ const EVENT_DEFINITIONS: &[EventDefinition] = &[
         source: EventSource::Solar(sun::SolarEvent::SolarNoon),
     },
     EventDefinition {
+        label: "📸 Golden dusk beg",
+        source: EventSource::Solar(sun::SolarEvent::GoldenDuskStart),
+    },
+    EventDefinition {
         label: "🌇 Sunset",
         source: EventSource::Solar(sun::SolarEvent::Sunset),
+    },
+    EventDefinition {
+        label: "📸 Golden dusk end",
+        source: EventSource::Solar(sun::SolarEvent::GoldenDuskEnd),
     },
     EventDefinition {
         label: "🌕 Moonrise",
@@ -58,8 +66,16 @@ const EVENT_DEFINITIONS: &[EventDefinition] = &[
         source: EventSource::Solar(sun::SolarEvent::CivilDawn),
     },
     EventDefinition {
+        label: "📸 Golden dawn beg",
+        source: EventSource::Solar(sun::SolarEvent::GoldenDawnStart),
+    },
+    EventDefinition {
         label: "🌅 Sunrise",
         source: EventSource::Solar(sun::SolarEvent::Sunrise),
+    },
+    EventDefinition {
+        label: "📸 Golden dawn end",
+        source: EventSource::Solar(sun::SolarEvent::GoldenDawnEnd),
     },
     EventDefinition {
         label: "🌑 Moonset",
@@ -273,6 +289,58 @@ fn calculate_dark_windows(
 
     // Don't record boundary artifacts - only actual transitions within the window
     events
+}
+
+/// Find the next dark-sky window at or after `reference`.
+///
+/// A dark-sky window is a period where the sun is below astronomical twilight
+/// (-18°) and the moon is below the horizon, using the same 15-minute moon-glow
+/// buffer as the events timeline (the DSD standard used by astrophotographers).
+///
+/// Scans forward up to 36 hours. If `reference` is already inside a dark window,
+/// the returned window starts at `reference`. The end time is `None` when the
+/// window extends beyond the scan horizon (possible at polar latitudes).
+pub fn next_dark_window(
+    location: &Location,
+    reference: &DateTime<Tz>,
+) -> Option<(DateTime<Tz>, Option<DateTime<Tz>>)> {
+    const MOON_GLOW_BUFFER_MINUTES: i64 = 15;
+    const STEP_MINUTES: i64 = 5;
+    const HORIZON_HOURS: i64 = 36;
+
+    let is_dark = |time: &DateTime<Tz>| {
+        sun::solar_position(location, time).altitude < -18.0
+            && is_moon_sufficiently_dark(location, time, MOON_GLOW_BUFFER_MINUTES)
+    };
+
+    let scan_end = reference.checked_add_signed(Duration::hours(HORIZON_HOURS))?;
+
+    let mut prev = *reference;
+    let mut prev_dark = is_dark(&prev);
+    let mut window_start: Option<DateTime<Tz>> = if prev_dark { Some(prev) } else { None };
+
+    let mut current = prev;
+    while current < scan_end {
+        current = current.checked_add_signed(Duration::minutes(STEP_MINUTES))?;
+        let dark = is_dark(&current);
+
+        if dark && !prev_dark && window_start.is_none() {
+            window_start = Some(refine_dark_window_transition(
+                location, &prev, &current, true,
+            ));
+        } else if !dark
+            && prev_dark
+            && let Some(start) = window_start
+        {
+            let end = refine_dark_window_transition(location, &prev, &current, false);
+            return Some((start, Some(end)));
+        }
+
+        prev = current;
+        prev_dark = dark;
+    }
+
+    window_start.map(|start| (start, None))
 }
 
 /// Refine dark window transition time using bisection

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@
 //! ## Features
 //!
 //! - **NOAA Solar Calculations**: Sunrise, sunset, solar noon, and twilight times (civil, nautical, astronomical)
-//! - **Meeus Lunar Algorithms**: Moonrise, moonset, lunar phases, and moon position
+//! - **Meeus Lunar Algorithms**: Moonrise, moonset, lunar phases, apsides (perigee/apogee), and moon position
+//! - **Photography Periods**: Golden hour and blue hour times, plus dark-sky windows for astrophotography
+//! - **Planets**: Positions, magnitudes, and rise/set times for the major planets (Mercury through Neptune)
+//! - **Seasons**: Equinox and solstice times (Meeus ch. 27)
 //! - **High Precision**: Matches U.S. Naval Observatory data within ±1-2 minutes
 //! - **City Database**: Built-in database of 570+ major cities worldwide
 //! - **Timezone Support**: Full timezone handling via `chrono-tz`
@@ -116,10 +119,16 @@ pub use config::Config;
 
 // Re-export essential astronomical types
 pub use astro::moon::{
-    LunarEvent, LunarPhase, LunarPhaseType, LunarPosition, lunar_event_time, lunar_phases,
-    lunar_position, phase_emoji, phase_name,
+    LunarApsis, LunarApsisKind, LunarEvent, LunarPhase, LunarPhaseType, LunarPosition,
+    SUPERMOON_DISTANCE_KM, is_supermoon, lunar_event_time, lunar_phases, lunar_position,
+    next_lunar_apsides, phase_emoji, phase_name,
 };
-pub use astro::sun::{SolarEvent, SolarPosition, solar_event_time, solar_noon, solar_position};
+pub use astro::planets::{Planet, PlanetEvent, PlanetPosition, planet_event_time, planet_position};
+pub use astro::seasons::{SeasonalEvent, SeasonalEventKind, next_seasonal_events, seasonal_events};
+pub use astro::sun::{
+    PhotoPeriods, SolarEvent, SolarPosition, photo_periods, solar_event_time, solar_noon,
+    solar_position,
+};
 
 /// Prelude module containing the most commonly used types and functions.
 ///
@@ -130,8 +139,12 @@ pub use astro::sun::{SolarEvent, SolarPosition, solar_event_time, solar_noon, so
 /// ```
 pub mod prelude {
     pub use crate::astro::Location;
-    pub use crate::astro::moon::{LunarEvent, LunarPhase, LunarPhaseType, LunarPosition};
-    pub use crate::astro::sun::{SolarEvent, SolarPosition};
+    pub use crate::astro::moon::{
+        LunarApsis, LunarEvent, LunarPhase, LunarPhaseType, LunarPosition,
+    };
+    pub use crate::astro::planets::{Planet, PlanetEvent, PlanetPosition};
+    pub use crate::astro::seasons::{SeasonalEvent, SeasonalEventKind};
+    pub use crate::astro::sun::{PhotoPeriods, SolarEvent, SolarPosition};
     pub use crate::city::{City, CityDatabase};
 
     // Convenience functions

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,26 @@ use location_source::LocationSource;
 fn main() -> Result<()> {
     let args = cli::Args::parse();
 
+    // Generator one-shots: no location, config, or network needed.
+    if let Some(shell) = args.completions {
+        use clap::CommandFactory;
+        let mut cmd = cli::Args::command();
+        clap_complete::generate(shell, &mut cmd, "solunatus", &mut io::stdout());
+        return Ok(());
+    }
+    if args.manpage {
+        use clap::CommandFactory;
+        let man = clap_mangen::Man::new(cli::Args::command());
+        man.render(&mut io::stdout())?;
+        return Ok(());
+    }
+
     // Load or create configuration
     let mut config = config::Config::load().ok().flatten();
 
     // Check system clock against authoritative source unless disabled by env/config.
-    let env_skips_time_sync = env::var("SOLUNATUS_SKIP_TIME_SYNC").is_ok();
+    // Scripting one-shots (--next) skip the sync so they stay fast and offline.
+    let env_skips_time_sync = env::var("SOLUNATUS_SKIP_TIME_SYNC").is_ok() || args.next.is_some();
     let (time_sync_info, time_sync_disabled, time_sync_server) =
         resolve_time_sync_state(config.as_ref(), env_skips_time_sync);
 
@@ -57,6 +72,11 @@ fn main() -> Result<()> {
         Local::now().with_timezone(&timezone)
     };
 
+    // Scripting query mode: print one value and exit.
+    if let Some(event) = args.next {
+        return run_next_query(event, args.format, &location, &dt);
+    }
+
     // Output mode
     if args.calendar {
         let start_str = args
@@ -76,6 +96,7 @@ fn main() -> Result<()> {
         let format = match args.calendar_format {
             cli::CalendarFormatArg::Html => calendar::CalendarFormat::Html,
             cli::CalendarFormatArg::Json => calendar::CalendarFormat::Json,
+            cli::CalendarFormatArg::Ics => calendar::CalendarFormat::Ics,
         };
 
         let calendar_output = calendar::generate_calendar(
@@ -247,6 +268,78 @@ fn main() -> Result<()> {
         let _ = saved_config.save();
     }
 
+    Ok(())
+}
+
+/// Compute the requested event's time on a given day (`None` if it doesn't occur).
+fn next_query_event_time(
+    event: cli::NextEventArg,
+    location: &astro::Location,
+    day: &chrono::DateTime<Tz>,
+) -> Option<chrono::DateTime<Tz>> {
+    use astro::moon::LunarEvent;
+    use astro::sun::SolarEvent;
+    use cli::NextEventArg;
+
+    let solar = |e| astro::sun::solar_event_time(location, day, e);
+    match event {
+        NextEventArg::Sunrise => solar(SolarEvent::Sunrise),
+        NextEventArg::Sunset => solar(SolarEvent::Sunset),
+        NextEventArg::SolarNoon => solar(SolarEvent::SolarNoon),
+        NextEventArg::CivilDawn => solar(SolarEvent::CivilDawn),
+        NextEventArg::CivilDusk => solar(SolarEvent::CivilDusk),
+        NextEventArg::NauticalDawn => solar(SolarEvent::NauticalDawn),
+        NextEventArg::NauticalDusk => solar(SolarEvent::NauticalDusk),
+        NextEventArg::AstronomicalDawn => solar(SolarEvent::AstronomicalDawn),
+        NextEventArg::AstronomicalDusk => solar(SolarEvent::AstronomicalDusk),
+        NextEventArg::GoldenDawnStart => solar(SolarEvent::GoldenDawnStart),
+        NextEventArg::GoldenDawnEnd => solar(SolarEvent::GoldenDawnEnd),
+        NextEventArg::GoldenDuskStart => solar(SolarEvent::GoldenDuskStart),
+        NextEventArg::GoldenDuskEnd => solar(SolarEvent::GoldenDuskEnd),
+        NextEventArg::Moonrise => {
+            astro::moon::lunar_event_time(location, day, LunarEvent::Moonrise)
+        }
+        NextEventArg::Moonset => astro::moon::lunar_event_time(location, day, LunarEvent::Moonset),
+    }
+}
+
+/// `--next` handler: find the next occurrence of an event after the reference
+/// time and print it in the requested format.
+fn run_next_query(
+    event: cli::NextEventArg,
+    format: cli::TimeFormatArg,
+    location: &astro::Location,
+    reference: &chrono::DateTime<Tz>,
+) -> Result<()> {
+    // 366 days covers polar-region gaps where an event can be absent for months.
+    const SEARCH_DAYS: i64 = 366;
+
+    let found = (0..SEARCH_DAYS).find_map(|offset| {
+        let day = reference.checked_add_signed(Duration::days(offset))?;
+        next_query_event_time(event, location, &day).filter(|t| t > reference)
+    });
+
+    let Some(time) = found else {
+        return Err(anyhow!(
+            "no occurrence of the requested event within the next {} days",
+            SEARCH_DAYS
+        ));
+    };
+
+    let line = match format {
+        cli::TimeFormatArg::Iso => time.to_rfc3339(),
+        cli::TimeFormatArg::Unix => time.timestamp().to_string(),
+        cli::TimeFormatArg::Local => time.format("%Y-%m-%d %H:%M:%S").to_string(),
+        cli::TimeFormatArg::Human => {
+            let until = astro::time_utils::time_until(reference, &time);
+            format!(
+                "{} ({})",
+                time.format("%Y-%m-%d %H:%M:%S %Z"),
+                astro::time_utils::format_duration_detailed(until)
+            )
+        }
+    };
+    println!("{}", line);
     Ok(())
 }
 
@@ -632,6 +725,23 @@ fn print_moon_section(moon_pos: &astro::moon::LunarPosition) {
     );
 }
 
+fn print_moon_apsides(apsides: &[astro::moon::LunarApsis], timezone: &Tz) {
+    for apsis in apsides {
+        let (label, marker) = match apsis.kind {
+            astro::moon::LunarApsisKind::Perigee => ("Next perigee:", "🔻"),
+            astro::moon::LunarApsisKind::Apogee => ("Next apogee:", "🔺"),
+        };
+        let local = apsis.datetime.with_timezone(timezone);
+        println!(
+            "{} {:<16}{} ({:.0} km)",
+            marker,
+            label,
+            local.format("%b %d %H:%M"),
+            apsis.distance_km
+        );
+    }
+}
+
 fn print_lunar_phases_section(phases: &[astro::moon::LunarPhase], timezone: &Tz) {
     if phases.is_empty() {
         return;
@@ -651,8 +761,121 @@ fn print_lunar_phases_section(phases: &[astro::moon::LunarPhase], timezone: &Tz)
             astro::moon::LunarPhaseType::FullMoon => "Full:",
             astro::moon::LunarPhaseType::LastQuarter => "Last quarter:",
         };
+        let supermoon = if astro::moon::is_supermoon(phase) {
+            " (Supermoon)"
+        } else {
+            ""
+        };
         let phase_dt = phase.datetime.with_timezone(timezone);
-        println!("{} {:<18} {}", emoji, name, phase_dt.format("%b %d %H:%M"));
+        println!(
+            "{} {:<18} {}{}",
+            emoji,
+            name,
+            phase_dt.format("%b %d %H:%M"),
+            supermoon
+        );
+    }
+}
+
+fn format_period(period: &Option<(chrono::DateTime<Tz>, chrono::DateTime<Tz>)>) -> String {
+    match period {
+        Some((start, end)) => format!("{}–{}", start.format("%H:%M"), end.format("%H:%M")),
+        None => "—".to_string(),
+    }
+}
+
+fn print_photography_section(location: &astro::Location, dt: &chrono::DateTime<Tz>) {
+    let periods = astro::sun::photo_periods(location, dt);
+
+    println!("— Photography —");
+    println!(
+        "📸 Golden hour:    {}, {}",
+        format_period(&periods.morning_golden),
+        format_period(&periods.evening_golden)
+    );
+    println!(
+        "🔵 Blue hour:      {}, {}",
+        format_period(&periods.morning_blue),
+        format_period(&periods.evening_blue)
+    );
+
+    match events::next_dark_window(location, dt) {
+        Some((start, Some(end))) => {
+            let minutes = end.signed_duration_since(start).num_minutes();
+            println!(
+                "🌌 Dark sky:       {} → {} ({}h {:02}m)",
+                start.format("%H:%M"),
+                end.format("%H:%M"),
+                minutes / 60,
+                minutes % 60
+            );
+        }
+        Some((start, None)) => {
+            println!(
+                "🌌 Dark sky:       from {} (beyond 36h scan)",
+                start.format("%b %d %H:%M")
+            );
+        }
+        None => {
+            println!("🌌 Dark sky:       none within 36h (moon or twilight interferes)");
+        }
+    }
+}
+
+fn print_planets_section(location: &astro::Location, dt: &chrono::DateTime<Tz>) {
+    println!("— Planets —");
+    for planet in astro::planets::Planet::ALL {
+        let pos = astro::planets::planet_position(planet, location, dt);
+        let rise = astro::planets::planet_event_time(
+            planet,
+            location,
+            dt,
+            astro::planets::PlanetEvent::Rise,
+        );
+        let set = astro::planets::planet_event_time(
+            planet,
+            location,
+            dt,
+            astro::planets::PlanetEvent::Set,
+        );
+        let rise_str = rise.map_or("—".to_string(), |t| t.format("%H:%M").to_string());
+        let set_str = set.map_or("—".to_string(), |t| t.format("%H:%M").to_string());
+
+        println!(
+            "{} {:<9}Alt {:>5.1}°, Az {:>3.0}° {:<3} mag {:>5.1}  ↑{} ↓{}",
+            planet.symbol(),
+            format!("{}:", planet.name()),
+            pos.altitude,
+            pos.azimuth,
+            astro::coordinates::azimuth_to_compass(pos.azimuth),
+            pos.magnitude,
+            rise_str,
+            set_str
+        );
+    }
+}
+
+fn print_seasons_section(dt: &chrono::DateTime<Tz>, timezone: &Tz) {
+    let upcoming = astro::seasons::next_seasonal_events(dt, 2);
+    if upcoming.is_empty() {
+        return;
+    }
+
+    println!("— Seasons —");
+    for event in upcoming {
+        let emoji = match event.kind {
+            astro::seasons::SeasonalEventKind::MarchEquinox => "🌱",
+            astro::seasons::SeasonalEventKind::JuneSolstice => "☀️",
+            astro::seasons::SeasonalEventKind::SeptemberEquinox => "🍂",
+            astro::seasons::SeasonalEventKind::DecemberSolstice => "❄️",
+        };
+        let local = event.datetime.with_timezone(timezone);
+        println!(
+            "{} {:<18} {}",
+            emoji,
+            format!("{}:", event.kind.name()),
+            local.format("%b %d %H:%M")
+        );
     }
 }
 
@@ -719,9 +942,14 @@ fn print_text_output(
     let moon_pos = astro::moon::lunar_position(location, dt);
     print_position_section(&sun_pos, &moon_pos);
     print_moon_section(&moon_pos);
+    print_moon_apsides(&astro::moon::next_lunar_apsides(dt), timezone);
 
     let phases = astro::moon::lunar_phases(dt.year(), dt.month());
     print_lunar_phases_section(&phases, timezone);
+
+    print_photography_section(location, dt);
+    print_planets_section(location, dt);
+    print_seasons_section(dt, timezone);
 
     if ai_config.enabled {
         let ai_events = ai::prepare_event_summaries(&events, dt, next_idx);
@@ -769,9 +997,14 @@ fn print_text_output(
     let moon_pos = astro::moon::lunar_position(location, dt);
     print_position_section(&sun_pos, &moon_pos);
     print_moon_section(&moon_pos);
+    print_moon_apsides(&astro::moon::next_lunar_apsides(dt), timezone);
 
     let phases = astro::moon::lunar_phases(dt.year(), dt.month());
     print_lunar_phases_section(&phases, timezone);
+
+    print_photography_section(location, dt);
+    print_planets_section(location, dt);
+    print_seasons_section(dt, timezone);
 
     Ok(())
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -28,6 +28,12 @@ pub struct JsonOutput {
     pub moon: MoonData,
     /// Lunar phases for current month
     pub lunar_phases: Vec<LunarPhaseData>,
+    /// Next dark-sky window (sun below -18°, moon below horizon)
+    pub dark_sky_window: Option<DarkSkyWindowData>,
+    /// Major planets (Mercury through Neptune)
+    pub planets: Vec<PlanetData>,
+    /// Upcoming equinoxes and solstices
+    pub seasons: Vec<SeasonData>,
     /// Optional AI-generated insights
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ai_insights: Option<AiInsightsData>,
@@ -66,6 +72,8 @@ pub struct SunData {
     pub position: PositionData,
     /// Solar events (sunrise, sunset, twilight times)
     pub events: SunEvents,
+    /// Golden hour and blue hour periods
+    pub photography: PhotographyData,
 }
 
 /// Lunar position, events, and phase for JSON output.
@@ -77,6 +85,90 @@ pub struct MoonData {
     pub events: MoonEvents,
     /// Current lunar phase details
     pub phase: PhaseData,
+    /// Next lunar perigee and apogee
+    pub apsides: Vec<ApsisData>,
+}
+
+/// A time period with start and end, formatted as "YYYY-MM-DD HH:MM:SS TZ".
+#[derive(Serialize)]
+pub struct PeriodData {
+    /// Period start time
+    pub start: String,
+    /// Period end time
+    pub end: String,
+}
+
+/// Golden hour and blue hour periods for JSON output.
+///
+/// Periods are `None` when the boundary altitudes are not crossed on the
+/// given day (polar day/night and high-latitude edge cases).
+#[derive(Serialize)]
+pub struct PhotographyData {
+    /// Morning blue hour (civil dawn → sun at -4°)
+    pub morning_blue: Option<PeriodData>,
+    /// Morning golden hour (sun -4° → +6°, rising)
+    pub morning_golden: Option<PeriodData>,
+    /// Evening golden hour (sun +6° → -4°, setting)
+    pub evening_golden: Option<PeriodData>,
+    /// Evening blue hour (sun at -4° → civil dusk)
+    pub evening_blue: Option<PeriodData>,
+}
+
+/// Next dark-sky window for JSON output.
+///
+/// A dark-sky window has the sun below astronomical twilight (-18°) and the
+/// moon below the horizon (with a 15-minute moon-glow buffer).
+#[derive(Serialize)]
+pub struct DarkSkyWindowData {
+    /// Window start time
+    pub start: String,
+    /// Window end time; `None` when the window extends beyond the 36-hour scan
+    pub end: Option<String>,
+    /// Window duration in minutes; `None` when the end is unknown
+    pub duration_minutes: Option<i64>,
+}
+
+/// A lunar apsis (perigee or apogee) for JSON output.
+#[derive(Serialize)]
+pub struct ApsisData {
+    /// "perigee" or "apogee"
+    pub kind: String,
+    /// Local time of the distance extremum
+    pub datetime: String,
+    /// Earth–moon distance in kilometers
+    pub distance_km: f64,
+}
+
+/// An upcoming equinox or solstice for JSON output.
+#[derive(Serialize)]
+pub struct SeasonData {
+    /// Event name (e.g. "March Equinox")
+    pub event: String,
+    /// Local time of the event
+    pub datetime: String,
+}
+
+/// A bright planet's position and events for JSON output.
+#[derive(Serialize)]
+pub struct PlanetData {
+    /// Planet name
+    pub name: String,
+    /// Altitude in degrees (+ above horizon, - below)
+    pub altitude: f64,
+    /// Azimuth in degrees (0° = North, clockwise)
+    pub azimuth: f64,
+    /// Compass direction (e.g., "NE", "SW")
+    pub azimuth_compass: String,
+    /// Geocentric distance in astronomical units
+    pub distance_au: f64,
+    /// Approximate visual magnitude (lower is brighter)
+    pub magnitude: f64,
+    /// Angular distance from the sun in degrees
+    pub elongation_degrees: f64,
+    /// Rise time, if the planet rises on this date
+    pub rise: Option<String>,
+    /// Set time, if the planet sets on this date
+    pub set: Option<String>,
 }
 
 /// Celestial body position (sun/moon) for JSON output.
@@ -163,6 +255,9 @@ pub struct LunarPhaseData {
     pub phase_type: String,
     /// UTC timestamp of phase event
     pub datetime: String,
+    /// Whether this full moon is a supermoon (only present for full moons)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supermoon: Option<bool>,
 }
 
 /// NTP time synchronization status for JSON output.
@@ -326,21 +421,7 @@ fn generate_json_output_impl(
 
     // Lunar phases for the month
     let phases = moon::lunar_phases(dt.year(), dt.month());
-    let lunar_phases: Vec<LunarPhaseData> = phases
-        .iter()
-        .map(|p| {
-            let phase_type = match p.phase_type {
-                moon::LunarPhaseType::NewMoon => "new_moon",
-                moon::LunarPhaseType::FirstQuarter => "first_quarter",
-                moon::LunarPhaseType::FullMoon => "full_moon",
-                moon::LunarPhaseType::LastQuarter => "last_quarter",
-            };
-            LunarPhaseData {
-                phase_type: phase_type.to_string(),
-                datetime: p.datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
-            }
-        })
-        .collect();
+    let lunar_phases = build_lunar_phase_data(&phases);
 
     let city_name_ref = city_name.as_deref();
     let ai_insights = if let Some(cfg) = ai_config {
@@ -398,6 +479,7 @@ fn generate_json_output_impl(
                 azimuth_compass: coordinates::azimuth_to_compass(sun_pos.azimuth).to_string(),
             },
             events: sun_events,
+            photography: build_photography_data(location, dt),
         },
         moon: MoonData {
             position: MoonPositionData {
@@ -414,8 +496,12 @@ fn generate_json_output_impl(
                 angle_degrees: moon_pos.phase_angle,
                 illumination_percent: moon_pos.illumination * 100.0,
             },
+            apsides: build_apsides_data(dt, timezone),
         },
         lunar_phases,
+        dark_sky_window: build_dark_sky_data(location, dt),
+        planets: build_planets_data(location, dt),
+        seasons: build_seasons_data(dt, timezone),
         ai_insights,
     };
 
@@ -466,21 +552,7 @@ fn generate_json_output_impl(
 
     // Calculate lunar phases for current month
     let phases = moon::lunar_phases(dt.year(), dt.month());
-    let lunar_phases = phases
-        .iter()
-        .map(|p| {
-            let phase_type = match p.phase_type {
-                moon::LunarPhaseType::NewMoon => "new_moon",
-                moon::LunarPhaseType::FirstQuarter => "first_quarter",
-                moon::LunarPhaseType::FullMoon => "full_moon",
-                moon::LunarPhaseType::LastQuarter => "last_quarter",
-            };
-            LunarPhaseData {
-                phase_type: phase_type.to_string(),
-                datetime: p.datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
-            }
-        })
-        .collect();
+    let lunar_phases = build_lunar_phase_data(&phases);
 
     let output = JsonOutput {
         location: LocationData {
@@ -505,6 +577,7 @@ fn generate_json_output_impl(
                 azimuth_compass: coordinates::azimuth_to_compass(sun_pos.azimuth).to_string(),
             },
             events: sun_events,
+            photography: build_photography_data(location, dt),
         },
         moon: MoonData {
             position: MoonPositionData {
@@ -521,12 +594,111 @@ fn generate_json_output_impl(
                 angle_degrees: moon_pos.phase_angle,
                 illumination_percent: moon_pos.illumination * 100.0,
             },
+            apsides: build_apsides_data(dt, timezone),
         },
         lunar_phases,
+        dark_sky_window: build_dark_sky_data(location, dt),
+        planets: build_planets_data(location, dt),
+        seasons: build_seasons_data(dt, timezone),
         ai_insights: None, // AI insights not available without the feature
     };
 
     Ok(serde_json::to_string_pretty(&output)?)
+}
+
+fn format_local_time(dt: &DateTime<Tz>) -> String {
+    dt.format("%Y-%m-%d %H:%M:%S %Z").to_string()
+}
+
+fn build_photography_data(location: &Location, dt: &DateTime<Tz>) -> PhotographyData {
+    let to_period = |period: Option<(DateTime<Tz>, DateTime<Tz>)>| {
+        period.map(|(start, end)| PeriodData {
+            start: format_local_time(&start),
+            end: format_local_time(&end),
+        })
+    };
+
+    let periods = sun::photo_periods(location, dt);
+    PhotographyData {
+        morning_blue: to_period(periods.morning_blue),
+        morning_golden: to_period(periods.morning_golden),
+        evening_golden: to_period(periods.evening_golden),
+        evening_blue: to_period(periods.evening_blue),
+    }
+}
+
+fn build_dark_sky_data(location: &Location, dt: &DateTime<Tz>) -> Option<DarkSkyWindowData> {
+    events::next_dark_window(location, dt).map(|(start, end)| DarkSkyWindowData {
+        start: format_local_time(&start),
+        end: end.as_ref().map(format_local_time),
+        duration_minutes: end.map(|e| e.signed_duration_since(start).num_minutes()),
+    })
+}
+
+fn build_apsides_data(dt: &DateTime<Tz>, timezone: &Tz) -> Vec<ApsisData> {
+    moon::next_lunar_apsides(dt)
+        .into_iter()
+        .map(|apsis| ApsisData {
+            kind: match apsis.kind {
+                moon::LunarApsisKind::Perigee => "perigee".to_string(),
+                moon::LunarApsisKind::Apogee => "apogee".to_string(),
+            },
+            datetime: format_local_time(&apsis.datetime.with_timezone(timezone)),
+            distance_km: apsis.distance_km,
+        })
+        .collect()
+}
+
+fn build_seasons_data(dt: &DateTime<Tz>, timezone: &Tz) -> Vec<SeasonData> {
+    seasons::next_seasonal_events(dt, 2)
+        .into_iter()
+        .map(|event| SeasonData {
+            event: event.kind.name().to_string(),
+            datetime: format_local_time(&event.datetime.with_timezone(timezone)),
+        })
+        .collect()
+}
+
+fn build_planets_data(location: &Location, dt: &DateTime<Tz>) -> Vec<PlanetData> {
+    planets::Planet::ALL
+        .into_iter()
+        .map(|planet| {
+            let pos = planets::planet_position(planet, location, dt);
+            PlanetData {
+                name: planet.name().to_string(),
+                altitude: pos.altitude,
+                azimuth: pos.azimuth,
+                azimuth_compass: coordinates::azimuth_to_compass(pos.azimuth).to_string(),
+                distance_au: pos.distance_au,
+                magnitude: pos.magnitude,
+                elongation_degrees: pos.elongation,
+                rise: planets::planet_event_time(planet, location, dt, planets::PlanetEvent::Rise)
+                    .map(|t| format_local_time(&t)),
+                set: planets::planet_event_time(planet, location, dt, planets::PlanetEvent::Set)
+                    .map(|t| format_local_time(&t)),
+            }
+        })
+        .collect()
+}
+
+fn build_lunar_phase_data(phases: &[moon::LunarPhase]) -> Vec<LunarPhaseData> {
+    phases
+        .iter()
+        .map(|p| {
+            let phase_type = match p.phase_type {
+                moon::LunarPhaseType::NewMoon => "new_moon",
+                moon::LunarPhaseType::FirstQuarter => "first_quarter",
+                moon::LunarPhaseType::FullMoon => "full_moon",
+                moon::LunarPhaseType::LastQuarter => "last_quarter",
+            };
+            LunarPhaseData {
+                phase_type: phase_type.to_string(),
+                datetime: p.datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+                supermoon: (p.phase_type == moon::LunarPhaseType::FullMoon)
+                    .then(|| moon::is_supermoon(p)),
+            }
+        })
+        .collect()
 }
 
 fn build_time_sync_data(time_sync_info: &time_sync::TimeSyncInfo) -> TimeSyncData {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -10,7 +10,7 @@ use crate::events;
 use crate::location_source::LocationSource;
 use crate::time_sync::TimeSyncInfo;
 use anyhow::{Context, Result, anyhow};
-use chrono::{DateTime, Duration as ChronoDuration, Local, NaiveDate};
+use chrono::{DateTime, Duration as ChronoDuration, Local, NaiveDate, TimeZone};
 use chrono_tz::Tz;
 use std::{
     fs,
@@ -21,7 +21,9 @@ use std::{
 };
 
 // Re-export types from submodules
-pub use super::cache::{CachedEvents, CachedMoonDetails, CachedPositions, MoonAltitudeTrend};
+pub use super::cache::{
+    CachedEvents, CachedMoonDetails, CachedPlanets, CachedPositions, MoonAltitudeTrend,
+};
 pub use super::drafts::{
     CalendarDraft, CalendarField, LocationInputDraft, LocationInputField, SettingsDraft,
     SettingsField,
@@ -35,6 +37,7 @@ const EVENT_WINDOW_HOURS: i64 = 12;
 const EVENT_REFRESH_THRESHOLD_HOURS: i64 = 6;
 const POSITION_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 const MOON_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
+const PLANET_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 const TIME_SYNC_REFRESH_INTERVAL: Duration = Duration::from_secs(1800); // 30 minutes (pool.ntp.org ToS compliance)
 
 #[derive(Debug, Clone, Copy)]
@@ -46,6 +49,16 @@ pub enum AppMode {
     AiConfig,
     Calendar,
     Reports,
+    Chart,
+}
+
+/// Cached sun/moon altitude curves for the chart view: one sample every
+/// 15 minutes across the local day, as (hour-of-day, altitude°) pairs.
+pub struct ChartCache {
+    pub sun: Vec<(f64, f64)>,
+    pub moon: Vec<(f64, f64)>,
+    pub generated_for: NaiveDate,
+    pub generated_at: Instant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,11 +106,15 @@ pub struct App {
     pub moon_overview_last_refresh: Instant,
     pub lunar_phases_cache: Vec<moon::LunarPhase>,
     pub lunar_phases_generated_for: NaiveDate,
+    pub planets_cache: CachedPlanets,
+    pub planets_last_refresh: Instant,
+    pub chart_cache: Option<ChartCache>,
     pub show_location_date: bool,
     pub show_events: bool,
     pub show_positions: bool,
     pub show_moon: bool,
     pub show_lunar_phases: bool,
+    pub show_planets: bool,
     #[cfg(feature = "ai-insights")]
     pub show_ai_insights: bool,
     pub time_sync_last_check: Instant,
@@ -145,6 +162,7 @@ impl App {
         );
         let positions_cache = CachedPositions::new(&location, &now_tz);
         let moon_overview_cache = CachedMoonDetails::from_positions(&location, &positions_cache);
+        let planets_cache = CachedPlanets::new(&location, &now_tz);
         let lunar_phases_cache = Self::collect_lunar_phases(&now_tz);
         let lunar_phases_generated_for = now_tz.date_naive();
         let prefs = watch_prefs.unwrap_or_default();
@@ -196,6 +214,7 @@ impl App {
                 show_positions: prefs.show_positions,
                 show_moon: prefs.show_moon,
                 show_lunar_phases: prefs.show_lunar_phases,
+                show_planets: prefs.show_planets,
                 night_mode: prefs.night_mode,
                 #[cfg(feature = "ai-insights")]
                 ai_enabled: ai_config.enabled,
@@ -238,11 +257,15 @@ impl App {
             moon_overview_last_refresh: Instant::now(),
             lunar_phases_cache,
             lunar_phases_generated_for,
+            planets_cache,
+            planets_last_refresh: Instant::now(),
+            chart_cache: None,
             show_location_date: prefs.show_location_date,
             show_events: prefs.show_events,
             show_positions: prefs.show_positions,
             show_moon: prefs.show_moon,
             show_lunar_phases: prefs.show_lunar_phases,
+            show_planets: prefs.show_planets,
             #[cfg(feature = "ai-insights")]
             show_ai_insights: prefs.show_ai_insights,
             time_sync_last_check: Instant::now(),
@@ -339,6 +362,21 @@ impl App {
         }
     }
 
+    fn recompute_planets(&mut self) {
+        let now_tz = self.current_time.with_timezone(&self.timezone);
+        self.planets_cache = CachedPlanets::new(&self.location, &now_tz);
+        self.planets_last_refresh = Instant::now();
+    }
+
+    pub fn refresh_planets_if_needed(&mut self) {
+        if !self.show_planets {
+            return;
+        }
+        if self.planets_last_refresh.elapsed() >= PLANET_REFRESH_INTERVAL {
+            self.recompute_planets();
+        }
+    }
+
     pub fn refresh_lunar_phases_if_needed(&mut self) {
         let now_tz = self.current_time.with_timezone(&self.timezone);
         if self.lunar_phases_cache.is_empty()
@@ -356,7 +394,11 @@ impl App {
         self.refresh_events_if_needed();
         self.refresh_positions_if_needed();
         self.refresh_moon_overview_if_needed();
+        self.refresh_planets_if_needed();
         self.refresh_lunar_phases_if_needed();
+        if matches!(self.mode, AppMode::Chart) {
+            self.refresh_chart_if_needed();
+        }
     }
 
     pub fn reset_cached_data(&mut self) {
@@ -365,9 +407,37 @@ impl App {
         self.moon_overview_cache =
             CachedMoonDetails::from_positions(&self.location, &self.positions_cache);
         self.moon_overview_last_refresh = Instant::now();
+        self.recompute_planets();
         let now_tz = self.current_time.with_timezone(&self.timezone);
         self.lunar_phases_cache = Self::collect_lunar_phases(&now_tz);
         self.lunar_phases_generated_for = now_tz.date_naive();
+        self.chart_cache = None;
+    }
+
+    /// Switch to the altitude chart view, (re)building the cached curves if needed.
+    pub fn enter_chart_mode(&mut self) {
+        self.refresh_chart_if_needed();
+        self.mode = AppMode::Chart;
+    }
+
+    pub fn refresh_chart_if_needed(&mut self) {
+        const CHART_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
+
+        let today = self.current_time.with_timezone(&self.timezone).date_naive();
+        let stale = match &self.chart_cache {
+            Some(cache) => {
+                cache.generated_for != today
+                    || cache.generated_at.elapsed() >= CHART_REFRESH_INTERVAL
+            }
+            None => true,
+        };
+        if stale {
+            self.chart_cache = self.build_chart_cache(today);
+        }
+    }
+
+    fn build_chart_cache(&self, today: NaiveDate) -> Option<ChartCache> {
+        compute_chart_cache(&self.location, &self.timezone, today)
     }
 
     pub fn watch_preferences(&self) -> WatchPreferences {
@@ -377,6 +447,7 @@ impl App {
             show_positions: self.show_positions,
             show_moon: self.show_moon,
             show_lunar_phases: self.show_lunar_phases,
+            show_planets: self.show_planets,
             #[cfg(feature = "ai-insights")]
             show_ai_insights: self.show_ai_insights,
             night_mode: self.night_mode,
@@ -456,6 +527,13 @@ impl App {
     pub fn position_countdown(&self) -> Duration {
         let elapsed = self.positions_last_refresh.elapsed();
         POSITION_REFRESH_INTERVAL
+            .checked_sub(elapsed)
+            .unwrap_or_else(|| Duration::from_secs(0))
+    }
+
+    pub fn planets_countdown(&self) -> Duration {
+        let elapsed = self.planets_last_refresh.elapsed();
+        PLANET_REFRESH_INTERVAL
             .checked_sub(elapsed)
             .unwrap_or_else(|| Duration::from_secs(0))
     }
@@ -856,6 +934,7 @@ impl App {
             show_positions: self.show_positions,
             show_moon: self.show_moon,
             show_lunar_phases: self.show_lunar_phases,
+            show_planets: self.show_planets,
             night_mode: self.night_mode,
             #[cfg(feature = "ai-insights")]
             ai_enabled: self.ai_config.enabled,
@@ -916,6 +995,7 @@ impl App {
         self.show_positions = self.settings_draft.show_positions;
         self.show_moon = self.settings_draft.show_moon;
         self.show_lunar_phases = self.settings_draft.show_lunar_phases;
+        self.show_planets = self.settings_draft.show_planets;
 
         // Apply night mode
         self.night_mode = self.settings_draft.night_mode;
@@ -949,6 +1029,7 @@ impl App {
             show_positions: true,
             show_moon: true,
             show_lunar_phases: true,
+            show_planets: true,
             night_mode: false,
             #[cfg(feature = "ai-insights")]
             ai_enabled: false,
@@ -1037,5 +1118,68 @@ impl App {
             self.settings_draft.ai_model = model.clone();
         }
         self.settings_draft.error = None;
+    }
+}
+
+/// Sample sun and moon altitude every 15 minutes across the local day,
+/// producing (hour-of-day, altitude°) pairs for the chart view.
+fn compute_chart_cache(location: &Location, timezone: &Tz, today: NaiveDate) -> Option<ChartCache> {
+    let midnight_naive = today.and_hms_opt(0, 0, 0)?;
+    let midnight = timezone
+        .from_local_datetime(&midnight_naive)
+        .earliest()
+        .or_else(|| {
+            timezone
+                .from_local_datetime(&(midnight_naive + ChronoDuration::hours(1)))
+                .earliest()
+        })?;
+
+    let samples = 96usize;
+    let mut sun_points = Vec::with_capacity(samples + 1);
+    let mut moon_points = Vec::with_capacity(samples + 1);
+
+    for i in 0..=samples {
+        let t = midnight + ChronoDuration::minutes(15 * i as i64);
+        let hour = i as f64 * 0.25;
+        sun_points.push((hour, sun::solar_position(location, &t).altitude));
+        moon_points.push((hour, moon::lunar_position(location, &t).altitude));
+    }
+
+    Some(ChartCache {
+        sun: sun_points,
+        moon: moon_points,
+        generated_for: today,
+        generated_at: Instant::now(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono_tz::America::New_York;
+
+    #[test]
+    fn chart_cache_samples_full_day() {
+        let location = Location::new(42.36, -71.06).unwrap(); // Boston
+        let today = NaiveDate::from_ymd_opt(2026, 6, 21).unwrap();
+
+        let cache = compute_chart_cache(&location, &New_York, today).expect("chart cache");
+
+        assert_eq!(cache.sun.len(), 97);
+        assert_eq!(cache.moon.len(), 97);
+        assert_eq!(cache.sun.first().unwrap().0, 0.0);
+        assert_eq!(cache.sun.last().unwrap().0, 24.0);
+
+        for points in [&cache.sun, &cache.moon] {
+            for &(hour, alt) in points {
+                assert!((0.0..=24.0).contains(&hour));
+                assert!((-90.0..=90.0).contains(&alt), "altitude {alt} out of range");
+            }
+        }
+
+        // Summer solstice in Boston: sun up at noon, down at midnight.
+        let noon_alt = cache.sun[48].1;
+        assert!(noon_alt > 60.0, "noon sun altitude {noon_alt} too low");
+        assert!(cache.sun[0].1 < 0.0, "midnight sun should be below horizon");
     }
 }

--- a/src/tui/cache.rs
+++ b/src/tui/cache.rs
@@ -4,8 +4,9 @@
 //! recomputation on every frame render.
 
 use crate::astro::moon::LunarPosition;
+use crate::astro::planets::{Planet, PlanetEvent, PlanetPosition};
 use crate::astro::sun::SolarPosition;
-use crate::astro::{Location, moon, sun};
+use crate::astro::{Location, moon, planets, sun};
 use chrono::DateTime;
 use chrono_tz::Tz;
 
@@ -44,6 +45,51 @@ impl CachedPositions {
             timestamp: *timestamp,
             sun: sun::solar_position(location, timestamp),
             moon: moon::lunar_position(location, timestamp),
+        }
+    }
+}
+
+// ============================================================================
+// Cached Planets
+// ============================================================================
+
+/// Position and rise/set times for one planet.
+#[derive(Debug, Clone, Copy)]
+pub struct CachedPlanet {
+    /// Which planet this entry describes
+    pub planet: Planet,
+    /// Apparent position and brightness
+    pub position: PlanetPosition,
+    /// Rise time on the local day, if any
+    pub rise: Option<DateTime<Tz>>,
+    /// Set time on the local day, if any
+    pub set: Option<DateTime<Tz>>,
+}
+
+/// Cached planet positions and rise/set times for the planets panel.
+#[derive(Debug, Clone)]
+pub struct CachedPlanets {
+    /// Timestamp when the entries were calculated
+    pub timestamp: DateTime<Tz>,
+    /// One entry per supported planet, in distance order from the sun
+    pub entries: Vec<CachedPlanet>,
+}
+
+impl CachedPlanets {
+    /// Compute positions and rise/set times for all supported planets.
+    pub fn new(location: &Location, timestamp: &DateTime<Tz>) -> Self {
+        let entries = Planet::ALL
+            .iter()
+            .map(|&planet| CachedPlanet {
+                planet,
+                position: planets::planet_position(planet, location, timestamp),
+                rise: planets::planet_event_time(planet, location, timestamp, PlanetEvent::Rise),
+                set: planets::planet_event_time(planet, location, timestamp, PlanetEvent::Set),
+            })
+            .collect();
+        Self {
+            timestamp: *timestamp,
+            entries,
         }
     }
 }

--- a/src/tui/drafts.rs
+++ b/src/tui/drafts.rs
@@ -169,7 +169,11 @@ pub struct CalendarDraft {
 
 impl CalendarDraft {
     const FIELD_COUNT: usize = 4;
-    const FORMATS: [CalendarFormat; 2] = [CalendarFormat::Html, CalendarFormat::Json];
+    const FORMATS: [CalendarFormat; 3] = [
+        CalendarFormat::Html,
+        CalendarFormat::Json,
+        CalendarFormat::Ics,
+    ];
 
     pub fn new(now: DateTime<Local>) -> Self {
         let today = now.date_naive();
@@ -223,6 +227,7 @@ impl CalendarDraft {
         match self.current_format() {
             CalendarFormat::Html => "HTML",
             CalendarFormat::Json => "JSON",
+            CalendarFormat::Ics => "ICS",
         }
     }
 
@@ -355,6 +360,7 @@ impl CalendarDraft {
         match format {
             CalendarFormat::Html => "html",
             CalendarFormat::Json => "json",
+            CalendarFormat::Ics => "ics",
         }
     }
 }
@@ -604,6 +610,7 @@ pub enum SettingsField {
     ShowPositions,
     ShowMoon,
     ShowLunarPhases,
+    ShowPlanets,
     NightMode,
     #[cfg(feature = "ai-insights")]
     AiEnabled,
@@ -625,6 +632,7 @@ pub struct SettingsDraft {
     pub show_positions: bool,
     pub show_moon: bool,
     pub show_lunar_phases: bool,
+    pub show_planets: bool,
     pub night_mode: bool,
     #[cfg(feature = "ai-insights")]
     pub ai_enabled: bool,
@@ -646,9 +654,9 @@ pub struct SettingsDraft {
 
 impl SettingsDraft {
     #[cfg(feature = "ai-insights")]
-    const FIELD_COUNT: usize = 13;
+    const FIELD_COUNT: usize = 14;
     #[cfg(not(feature = "ai-insights"))]
-    const FIELD_COUNT: usize = 9;
+    const FIELD_COUNT: usize = 10;
 
     pub fn current_field(&self) -> SettingsField {
         match self.field_index {
@@ -660,13 +668,14 @@ impl SettingsDraft {
             5 => SettingsField::ShowPositions,
             6 => SettingsField::ShowMoon,
             7 => SettingsField::ShowLunarPhases,
-            8 => SettingsField::NightMode,
+            8 => SettingsField::ShowPlanets,
+            9 => SettingsField::NightMode,
             #[cfg(feature = "ai-insights")]
-            9 => SettingsField::AiEnabled,
+            10 => SettingsField::AiEnabled,
             #[cfg(feature = "ai-insights")]
-            10 => SettingsField::AiServer,
+            11 => SettingsField::AiServer,
             #[cfg(feature = "ai-insights")]
-            11 => SettingsField::AiModel,
+            12 => SettingsField::AiModel,
             #[cfg(feature = "ai-insights")]
             _ => SettingsField::AiRefreshMinutes,
             #[cfg(not(feature = "ai-insights"))]
@@ -692,6 +701,7 @@ impl SettingsDraft {
             SettingsField::ShowPositions => self.show_positions = !self.show_positions,
             SettingsField::ShowMoon => self.show_moon = !self.show_moon,
             SettingsField::ShowLunarPhases => self.show_lunar_phases = !self.show_lunar_phases,
+            SettingsField::ShowPlanets => self.show_planets = !self.show_planets,
             SettingsField::NightMode => self.night_mode = !self.night_mode,
             #[cfg(feature = "ai-insights")]
             SettingsField::AiEnabled => self.ai_enabled = !self.ai_enabled,

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -33,7 +33,22 @@ fn handle_key_event(app: &mut App, key: KeyEvent) -> Result<()> {
         }
         AppMode::Calendar => handle_calendar_keys(app, key),
         AppMode::Reports => handle_reports_keys(app, key),
+        AppMode::Chart => handle_chart_keys(app, key),
     }
+}
+
+fn handle_chart_keys(app: &mut App, key: KeyEvent) -> Result<()> {
+    match key.code {
+        KeyCode::Esc
+        | KeyCode::Char('q')
+        | KeyCode::Char('Q')
+        | KeyCode::Char('g')
+        | KeyCode::Char('G') => {
+            app.mode = AppMode::Watch;
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn handle_watch_mode_keys(app: &mut App, key: KeyEvent) -> Result<()> {
@@ -49,6 +64,10 @@ fn handle_watch_mode_keys(app: &mut App, key: KeyEvent) -> Result<()> {
             // Open reports menu
             app.mode = AppMode::Reports;
             app.reports_selected_item = super::app::ReportsMenuItem::Calendar;
+        }
+        KeyCode::Char('g') | KeyCode::Char('G') => {
+            // Open the sun/moon altitude chart
+            app.enter_chart_mode();
         }
         #[cfg(feature = "ai-insights")]
         KeyCode::Char('f') | KeyCode::Char('F') if app.ai_config.enabled => {
@@ -161,6 +180,7 @@ fn handle_settings_keys(app: &mut App, key: KeyEvent) -> Result<()> {
                 | SettingsField::ShowPositions
                 | SettingsField::ShowMoon
                 | SettingsField::ShowLunarPhases
+                | SettingsField::ShowPlanets
                 | SettingsField::NightMode => {
                     app.settings_draft.toggle_current_bool();
                 }
@@ -377,6 +397,10 @@ fn handle_calendar_keys(app: &mut App, key: KeyEvent) -> Result<()> {
                     'j' | 'J' => {
                         app.calendar_draft
                             .set_format(crate::calendar::CalendarFormat::Json);
+                    }
+                    'i' | 'I' => {
+                        app.calendar_draft
+                            .set_format(crate::calendar::CalendarFormat::Ics);
                     }
                     _ => {}
                 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5,7 +5,7 @@ use super::app::{AiConfigField, AiServerStatus};
 use super::app::{App, CalendarField, LocationInputField, SettingsField};
 use crate::astro::*;
 use crate::time_sync;
-use chrono::{Offset, Utc};
+use chrono::{Offset, Timelike, Utc};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 
 #[cfg(feature = "ai-insights")]
 fn get_footer_instructions(ai_enabled: bool) -> Vec<&'static str> {
-    let mut instructions = vec!["q quit", "s settings", "r reports"];
+    let mut instructions = vec!["q quit", "s settings", "r reports", "g graph"];
     if ai_enabled {
         instructions.push("f fetch AI");
     }
@@ -26,7 +26,7 @@ fn get_footer_instructions(ai_enabled: bool) -> Vec<&'static str> {
 
 #[cfg(not(feature = "ai-insights"))]
 fn get_footer_instructions(_ai_enabled: bool) -> Vec<&'static str> {
-    vec!["q quit", "s settings", "r reports"]
+    vec!["q quit", "s settings", "r reports", "g graph"]
 }
 
 pub fn render(f: &mut Frame, app: &App) {
@@ -83,7 +83,98 @@ pub fn render(f: &mut Frame, app: &App) {
         super::app::AppMode::Reports => {
             render_reports_menu(f, app);
         }
+        super::app::AppMode::Chart => {
+            render_altitude_chart(f, app);
+        }
     }
+}
+
+fn render_altitude_chart(f: &mut Frame, app: &App) {
+    use ratatui::symbols::Marker;
+    use ratatui::widgets::{Axis, Chart, Dataset, GraphType};
+
+    let area = f.area();
+    let now_tz = app.current_time.with_timezone(&app.timezone);
+
+    let Some(cache) = &app.chart_cache else {
+        let message = Paragraph::new("Computing altitude curves…")
+            .style(Style::default().fg(get_color(app, Color::Gray)))
+            .alignment(Alignment::Center)
+            .block(bordered_block(app));
+        f.render_widget(message, area);
+        return;
+    };
+
+    // Vertical "now" marker and a horizon reference line.
+    let now_hour = f64::from(now_tz.hour()) + f64::from(now_tz.minute()) / 60.0;
+    let now_line: Vec<(f64, f64)> = (0..=36)
+        .map(|i| (now_hour, -90.0 + f64::from(i) * 5.0))
+        .collect();
+    let horizon: Vec<(f64, f64)> = (0..=96).map(|i| (f64::from(i) * 0.25, 0.0)).collect();
+
+    let sun_style = Style::default().fg(get_color(app, Color::Yellow));
+    let moon_style = Style::default().fg(get_color(app, Color::Cyan));
+    let now_style = Style::default().fg(get_color(app, Color::Magenta));
+    let horizon_style = Style::default().fg(get_color(app, Color::DarkGray));
+
+    let datasets = vec![
+        Dataset::default()
+            .name("Horizon")
+            .marker(Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(horizon_style)
+            .data(&horizon),
+        Dataset::default()
+            .name(label_with_symbol(
+                app,
+                symbol_prefix(app, "☀️"),
+                "Sun".to_string(),
+            ))
+            .marker(Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(sun_style)
+            .data(&cache.sun),
+        Dataset::default()
+            .name(label_with_symbol(
+                app,
+                symbol_prefix(app, "🌕"),
+                "Moon".to_string(),
+            ))
+            .marker(Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(moon_style)
+            .data(&cache.moon),
+        Dataset::default()
+            .name("Now")
+            .marker(Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(now_style)
+            .data(&now_line),
+    ];
+
+    let axis_style = Style::default().fg(get_color(app, Color::Gray));
+    let chart = Chart::new(datasets)
+        .block(bordered_block(app).title(format!(
+            " Altitude — {} ({})  [g/Esc back] ",
+            now_tz.format("%b %d"),
+            app.timezone.name()
+        )))
+        .x_axis(
+            Axis::default()
+                .title("Local time")
+                .style(axis_style)
+                .bounds([0.0, 24.0])
+                .labels(["00:00", "06:00", "12:00", "18:00", "24:00"]),
+        )
+        .y_axis(
+            Axis::default()
+                .title("Altitude °")
+                .style(axis_style)
+                .bounds([-90.0, 90.0])
+                .labels(["-90", "-45", "0", "+45", "+90"]),
+        );
+
+    f.render_widget(chart, area);
 }
 
 fn get_color(app: &App, default_color: Color) -> Color {
@@ -359,7 +450,7 @@ fn render_main_content(f: &mut Frame, area: Rect, app: &App) {
             };
 
             let event_label = sanitized_event_label(app, event_name);
-            let (event_width, diff_width) = if app.night_mode { (14, 15) } else { (16, 17) };
+            let (event_width, diff_width) = if app.night_mode { (15, 15) } else { (17, 17) };
             lines.push(Line::from(vec![Span::raw(format!(
                 "{}  {:<event_width$} {:<diff_width$}{}",
                 time_str,
@@ -405,6 +496,43 @@ fn render_main_content(f: &mut Frame, area: Rect, app: &App) {
                 coordinates::azimuth_to_compass(moon_pos_position.azimuth)
             ),
         ))]));
+        sections_rendered += 1;
+    }
+
+    if app.show_planets {
+        if sections_rendered > 0 {
+            lines.push(Line::from(""));
+        }
+        let planets_seconds = app.planets_countdown().as_secs();
+        lines.push(Line::from(vec![Span::styled(
+            format!("— Planets —  ↻{}s", planets_seconds),
+            Style::default()
+                .fg(get_color(app, Color::Yellow))
+                .add_modifier(Modifier::BOLD),
+        )]));
+
+        for entry in &app.planets_cache.entries {
+            let rise_str = entry
+                .rise
+                .map_or("—".to_string(), |t| t.format("%H:%M").to_string());
+            let set_str = entry
+                .set
+                .map_or("—".to_string(), |t| t.format("%H:%M").to_string());
+            lines.push(Line::from(vec![Span::raw(label_with_symbol(
+                app,
+                entry.planet.symbol(),
+                format!(
+                    "{:<9}Alt {:>5.1}°, Az {:>3.0}° {:<3} mag {:>5.1}  ↑{} ↓{}",
+                    format!("{}:", entry.planet.name()),
+                    entry.position.altitude,
+                    entry.position.azimuth,
+                    coordinates::azimuth_to_compass(entry.position.azimuth),
+                    entry.position.magnitude,
+                    rise_str,
+                    set_str
+                ),
+            ))]));
+        }
         sections_rendered += 1;
     }
 
@@ -1398,6 +1526,20 @@ fn render_settings(f: &mut Frame, app: &App) {
         current_field == SettingsField::ShowLunarPhases,
         "Lunar Phases",
         if draft.show_lunar_phases {
+            "[x] Show"
+        } else {
+            "[ ] Hide"
+        }
+        .to_string(),
+        None,
+    );
+
+    render_setting_field(
+        &mut lines,
+        app,
+        current_field == SettingsField::ShowPlanets,
+        "Planets",
+        if draft.show_planets {
             "[x] Show"
         } else {
             "[ ] Hide"


### PR DESCRIPTION
## Summary

The v0.6.0 feature batch, plus the new TUI planets panel and an events alignment fix.

### New astronomy features
- **`astro::planets`**: apparent positions (alt/az, distance, visual magnitude, solar elongation) and rise/set times for all seven major planets (Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune), computed from Schlyter Keplerian mean elements with the major Jupiter–Saturn and Uranus perturbation terms. Surfaced in the text output, the JSON `planets` array, and a new TUI watch panel with a 60-second refresh countdown, toggleable in settings and persisted as `watch.show_planets`.
- **`astro::seasons`**: equinox and solstice times (Meeus ch. 27 with ΔT correction), next two events in text and JSON.
- **Golden/blue hour**: new `SolarEvent` variants at the −4°/+6° photography thresholds, golden hour entries in the events timeline, a Photography section, and a `sun.photography` JSON block.
- **Dark-sky window**: `events::next_dark_window` scans 36h ahead for sun < −18° with the moon down.
- **Lunar apsides**: next perigee/apogee with supermoon flagging.

### New output/automation features
- iCalendar export (`--calendar-format ics`, RFC 5545)
- Scripting query mode (`--next <event>`, `--format iso|unix|local|human`)
- Shell completions (`--completions`) and man page (`--manpage`)
- TUI altitude chart view (`g` key)

### Fixes
- Widened the TUI events label column (16→17 normal, 14→15 night mode) so the 17-character golden hour labels no longer overflow and push their countdown durations out of alignment.

### Version
- Bumped to **0.6.0** in `Cargo.toml`, which drives the TUI title bar and `--version`.

## Test plan
- [x] `cargo test`: 44 unit + 44 doc tests pass, including new regression tests (great conjunction 2020 anchor, Mercury/Venus elongation bounds, geocentric distance bounds for all seven planets, rise/set horizon crossing)
- [x] `cargo clippy --all-targets`: zero warnings
- [x] Manual verification of text, JSON, and TUI output for Boston (magnitudes match real-world values: Venus −3.8, Uranus 5.8, Neptune 7.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)