### PR TITLE
release: prepare 0.6.0 — 100% docs coverage, JPL Horizons planet validation, Linux binaries

### DIFF
--- a/.github/workflows/planet-validation.yml
+++ b/.github/workflows/planet-validation.yml
@@ -1,0 +1,66 @@
+name: Planet Validation Drift
+
+on:
+  schedule:
+    - cron: "45 10 * * 1"
+  workflow_dispatch:
+    inputs:
+      max_angle:
+        description: "Maximum allowed az/alt deviation vs JPL Horizons (degrees)"
+        required: false
+        default: "0.25"
+      max_mag:
+        description: "Maximum allowed visual magnitude deviation"
+        required: false
+        default: "0.8"
+      max_dist_frac:
+        description: "Maximum allowed relative distance error (fraction)"
+        required: false
+        default: "0.005"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  planet_drift_validation:
+    name: Planet Drift Validation (JPL Horizons)
+    runs-on: ubuntu-latest
+    env:
+      MAX_ANGLE: ${{ inputs.max_angle || '0.25' }}
+      MAX_MAG: ${{ inputs.max_mag || '0.8' }}
+      MAX_DIST_FRAC: ${{ inputs.max_dist_frac || '0.005' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+      - name: Build solunatus
+        run: cargo build --release --locked --no-default-features
+      - name: Run planet drift check against JPL Horizons
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/planet_drift_check.py \
+            --binary ./target/release/solunatus \
+            --max-angle "${MAX_ANGLE}" \
+            --max-mag "${MAX_MAG}" \
+            --max-dist-frac "${MAX_DIST_FRAC}" \
+            | tee planet-drift-report.txt
+      - name: Publish report summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Planet Drift Validation (JPL Horizons)"
+            echo ""
+            if [[ -f planet-drift-report.txt ]]; then
+              echo '```'
+              cat planet-drift-report.txt
+              echo '```'
+            else
+              echo "No report was generated."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ src/bin/calendar_benchmark.rs
 # Benchmark output files
 *.html
 test_benchmark.sh
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-06-10
 
 ### Added
+- **Planet accuracy validation**: Planet positions are validated against the JPL Horizons ephemeris (altitude/azimuth within 0.06° across 1990–2049, ≈ a few seconds of rise/set time). New offline regression tests (`tests/planet_accuracy.rs`) pin Horizons reference values at three epochs and run on every build; a new scheduled CI workflow (`planet-validation.yml`, via `scripts/planet_drift_check.py`) re-checks live Horizons data weekly with thresholds of 0.25° position, 0.8 magnitude, and 0.5% distance
 - **Planets**: New `astro::planets` module computing apparent positions (altitude, azimuth, distance, approximate visual magnitude, solar elongation) and rise/set times for the seven major planets (Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune) from Keplerian mean elements with the major Jupiter–Saturn and Uranus perturbation terms; surfaced as a "— Planets —" text section and a `planets` array in JSON output, with a regression test anchored to the December 2020 Jupiter–Saturn great conjunction
 - **Seasons**: New `astro::seasons` module computing equinoxes and solstices (Meeus ch. 27, validated against the book's worked example) with ΔT correction to UTC; the next two seasonal events appear in text and JSON output
 - **Golden/blue hour**: Four new `SolarEvent` variants at the -4° and +6° photography thresholds (`GoldenDawnStart/End`, `GoldenDuskStart/End`), a `photo_periods` helper returning the morning/evening golden hour and blue hour ranges, golden hour entries in the events timeline, a "— Photography —" text section, and a `sun.photography` JSON block
@@ -20,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TUI planets panel**: The watch view gains a "— Planets —" section with a 60-second refresh countdown showing altitude, azimuth with compass direction, visual magnitude, and rise/set times for all seven major planets; toggleable via a new "Planets" entry in the settings Panel Visibility section, persisted as `watch.show_planets` in the config file
 
 ### Fixed
+- **Feature-gated builds**: Builds with `--no-default-features` produced no output at all — a misplaced `#[cfg(feature = "usno-validation")]` attribute compiled out the entire output-mode dispatch (JSON, watch, and text modes), so the binary silently exited. The gate now applies only to the `--validate` branch
 - **TUI events alignment**: Widened the events label column (16→17 normal, 14→15 night mode) so the 17-character golden hour labels no longer overflow it and push their countdown durations one column out of alignment with the other events
 - **ICS phase boundary**: The iCalendar export now scans one UTC month past each end of the requested range when collecting quarter lunar phases, so a phase whose UTC timestamp falls in the neighboring month but whose local date is inside the range (e.g. the 2026-12-01 06:14 UTC last quarter, which is Nov 30 in America/Los_Angeles) is no longer dropped
 
 ### Changed
+- **Documentation**: API documentation coverage raised from ~86% to 100% — all public items (the `astro::units` type-safe wrappers, `ai` configuration methods, `BatchResult`/`LibraryInfo` fields, and the `coordinates`/`time_utils` modules) now carry doc comments, and `#![warn(missing_docs)]` keeps it that way; refreshed the README for the 0.6.0 feature set
 - **Dependencies**: Updated `ratatui` to 0.30.1 and `chrono` to 0.4.45 via the production-dependencies group (supersedes Dependabot PR #72); `chrono` 0.4.45 rejects a TZ offset hour of 24 to avoid a `FixedOffset` overflow, and the `ratatui` bump pulls in refreshed transitive crates (`lru` 0.18.0, `strum` 0.28.0, `bitflags` 2.13.0, and the new `palette` color stack). Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -15,11 +15,16 @@ Solunatus runs offline for core calculations and supports historical/future date
 
 - Sunrise, sunset, and solar noon
 - Civil, nautical, and astronomical twilight
+- Golden hour and blue hour times, plus dark-sky windows for astrophotography
 - Moonrise, moonset, and transit
-- Moon phase, illumination, altitude/azimuth, distance
+- Moon phase, illumination, altitude/azimuth, distance, perigee/apogee, supermoons
+- Planet positions, magnitudes, and rise/set times (Mercury through Neptune), validated against JPL Horizons
+- Equinox and solstice times
 - Built-in city database (570+ cities)
-- Interactive terminal UI (watch mode)
-- JSON output and calendar export (HTML/JSON)
+- Interactive terminal UI (watch mode) with planets panel and altitude chart
+- JSON output and calendar export (HTML/JSON/iCalendar)
+- Scripting query mode (`--next sunrise`) for cron and automation
+- Shell completions and man page generation
 - Optional USNO validation reports
 - Optional AI insights via local Ollama
 
@@ -91,6 +96,19 @@ solunatus --city "Lisbon" \
   --calendar-output lisbon-jan-2026.html
 ```
 
+### Next event query (scripting/automation)
+
+```bash
+solunatus --city "Denver" --next sunset --format iso
+```
+
+### Shell completions and man page
+
+```bash
+solunatus --completions zsh > _solunatus
+solunatus --manpage > solunatus.1
+```
+
 ### USNO validation report (feature-enabled builds)
 
 ```bash
@@ -111,8 +129,11 @@ Core flags:
 - `--date <YYYY-MM-DD>`
 - `--json`
 - `--calendar --calendar-start <DATE> --calendar-end <DATE>`
-- `--calendar-format <html|json>`
+- `--calendar-format <html|json|ics>`
 - `--calendar-output <PATH>`
+- `--next <EVENT> --format <iso|unix|local|human>`
+- `--completions <SHELL>`
+- `--manpage`
 - `--watch`
 - `--no-prompt`
 - `--no-save`
@@ -149,7 +170,7 @@ Add dependency:
 
 ```toml
 [dependencies]
-solunatus = "0.5.0"
+solunatus = "0.6.0"
 chrono = "0.4"
 chrono-tz = "0.10"
 ```
@@ -183,6 +204,8 @@ More examples: [`examples/`](examples/)
 ## Accuracy and Scope
 
 Solunatus uses NOAA-based solar methods and Meeus-based lunar methods, with validation tooling aligned to USNO-style conventions.
+
+Planet positions use Keplerian mean elements with the major Jupiter, Saturn, and Uranus perturbation terms. They are validated against the JPL Horizons ephemeris: altitude/azimuth agree within 0.06° across 1990–2049 (a few seconds of rise/set time). Offline regression tests pin Horizons reference values on every build, and a scheduled CI workflow re-checks live Horizons data weekly.
 
 This project is intended for educational, planning, and general-purpose astronomical use.  
 It is not certified for safety-critical navigation or legal timing decisions.

--- a/scripts/planet_drift_check.py
+++ b/scripts/planet_drift_check.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate solunatus planet positions against JPL Horizons.
+
+Runs the solunatus binary in JSON mode for one or more dates, queries the
+JPL Horizons API (the gold-standard ephemeris) for the same instants and
+observer location, and gates each planet's altitude/azimuth/magnitude/distance
+deltas against thresholds.
+
+Used by the scheduled planet-validation CI workflow; also runnable locally:
+
+    cargo build --release
+    python3 scripts/planet_drift_check.py --binary ./target/release/solunatus
+
+Exit status is non-zero if any delta exceeds its threshold.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+HORIZONS_API = "https://ssd.jpl.nasa.gov/api/horizons.api"
+
+PLANET_IDS = {
+    "Mercury": "199",
+    "Venus": "299",
+    "Mars": "499",
+    "Jupiter": "599",
+    "Saturn": "699",
+    "Uranus": "799",
+    "Neptune": "899",
+}
+
+# Default test epochs (local dates; solunatus resolves --date to local noon).
+DEFAULT_DATES = ["2026-06-15", "2030-03-01", "2040-09-10"]
+
+# Default observer: Boston, USA.
+DEFAULT_LAT = 42.3601
+DEFAULT_LON = -71.0589
+DEFAULT_TZ = "America/New_York"
+
+# Thresholds. The planet model uses Keplerian mean elements with major
+# Jupiter/Saturn/Uranus perturbation terms, so a few hundredths of a degree
+# of drift vs the JPL integrated ephemeris is expected and fine for
+# rise/set-level accuracy (0.25 deg of sky motion is ~1 minute of time).
+# Observed 1990-2049: positions within 0.06 deg, distance within 0.41%.
+MAX_ANGLE_DEG = 0.25
+# Magnitudes use simple phase-angle formulas that degrade for Venus as a
+# thin crescent near inferior conjunction (observed 0.64 mag off in Jan
+# 1990); everything else stays within ~0.25 mag.
+MAX_MAG = 0.8
+MAX_DIST_FRAC = 0.005  # relative error in distance
+
+
+def run_solunatus(binary, date, lat, lon, tz):
+    cmd = [
+        binary,
+        "--lat", str(lat),
+        f"--lon={lon}",
+        "--tz", tz,
+        "--date", date,
+        "--json",
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(out.stdout)
+
+
+def query_horizons(planet_id, utc_str, lat, lon, retries=3):
+    # utc_str: "YYYY-MM-DD HH:MM:SS UTC" from solunatus JSON output
+    start = utc_str.replace(" UTC", "")
+    params = {
+        "format": "text",
+        "COMMAND": f"'{planet_id}'",
+        "OBJ_DATA": "'NO'",
+        "MAKE_EPHEM": "'YES'",
+        "EPHEM_TYPE": "'OBSERVER'",
+        "CENTER": "'coord@399'",
+        "COORD_TYPE": "'GEODETIC'",
+        "SITE_COORD": f"'{lon},{lat},0'",
+        "START_TIME": f"'{start}'",
+        "STOP_TIME": f"'{start[:-2]}59'",
+        "STEP_SIZE": "'2'",
+        "QUANTITIES": "'4,9,20'",  # apparent az/el, vis. magnitude, range
+        "ANG_FORMAT": "'DEG'",
+        "APPARENT": "'AIRLESS'",
+    }
+    url = HORIZONS_API + "?" + urllib.parse.urlencode(params)
+    last_err = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(url, timeout=60) as resp:
+                text = resp.read().decode()
+            break
+        except Exception as err:  # noqa: BLE001 - retry any transport error
+            last_err = err
+            time.sleep(5 * (attempt + 1))
+    else:
+        raise RuntimeError(f"Horizons query failed for {planet_id}: {last_err}")
+
+    if "$$SOE" not in text:
+        raise RuntimeError(f"No ephemeris data in Horizons response for {planet_id}:\n{text[:500]}")
+    line = text.split("$$SOE")[1].strip().splitlines()[0]
+    # Format: date time [flags] az el mag surf_brt range range_rate
+    nums = [p for p in line.split() if re.match(r"^-?\d+\.?\d*$", p)]
+    return {
+        "azimuth": float(nums[0]),
+        "altitude": float(nums[1]),
+        "magnitude": float(nums[2]),
+        "distance_au": float(nums[4]),
+    }
+
+
+def angle_delta(a, b):
+    d = abs(a - b) % 360.0
+    return min(d, 360.0 - d)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default="./target/release/solunatus")
+    parser.add_argument("--dates", nargs="*", default=DEFAULT_DATES)
+    parser.add_argument("--lat", type=float, default=DEFAULT_LAT)
+    parser.add_argument("--lon", type=float, default=DEFAULT_LON)
+    parser.add_argument("--tz", default=DEFAULT_TZ)
+    parser.add_argument("--max-angle", type=float, default=MAX_ANGLE_DEG)
+    parser.add_argument("--max-mag", type=float, default=MAX_MAG)
+    parser.add_argument("--max-dist-frac", type=float, default=MAX_DIST_FRAC)
+    args = parser.parse_args()
+
+    failures = 0
+    for date in args.dates:
+        data = run_solunatus(args.binary, date, args.lat, args.lon, args.tz)
+        utc = data["datetime"]["utc"]
+        planets = {p["name"]: p for p in data["planets"]}
+        print(f"\n=== {date} (UTC {utc}) lat={args.lat} lon={args.lon} ===")
+        print(f"{'Planet':9} {'dAz(deg)':>9} {'dAlt(deg)':>10} {'dMag':>6} {'dDist(%)':>9}  result")
+        for name, pid in PLANET_IDS.items():
+            ref = query_horizons(pid, utc, args.lat, args.lon)
+            got = planets[name]
+            d_az = angle_delta(got["azimuth"], ref["azimuth"])
+            d_alt = abs(got["altitude"] - ref["altitude"])
+            d_mag = abs(got["magnitude"] - ref["magnitude"])
+            d_dist = abs(got["distance_au"] - ref["distance_au"]) / ref["distance_au"]
+            ok = (
+                d_az <= args.max_angle
+                and d_alt <= args.max_angle
+                and d_mag <= args.max_mag
+                and d_dist <= args.max_dist_frac
+            )
+            if not ok:
+                failures += 1
+            print(
+                f"{name:9} {d_az:9.4f} {d_alt:10.4f} {d_mag:6.2f} {d_dist * 100:9.4f}  "
+                + ("PASS" if ok else "FAIL")
+            )
+            # Horizons asks API users to keep request rates modest.
+            time.sleep(1)
+
+    if failures:
+        print(f"\n{failures} planet check(s) exceeded thresholds", file=sys.stderr)
+        return 1
+    print("\nAll planet checks within thresholds.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -256,6 +256,7 @@ struct OllamaRequest<'a> {
 }
 
 impl AiConfig {
+    /// Build an AI configuration from parsed CLI arguments, validating the refresh interval.
     pub fn from_args(args: &crate::cli::Args) -> Result<Self> {
         let enabled = args.ai_insights;
         let refresh_minutes = args.ai_refresh_minutes;
@@ -275,15 +276,18 @@ impl AiConfig {
         })
     }
 
+    /// Overlay settings persisted in the config file onto this configuration.
     pub fn merge_with_saved(mut self, saved_settings: &crate::config::AiSettings) -> Self {
         self.refresh_mode = saved_settings.refresh_mode;
         self
     }
 
+    /// Full URL of the Ollama generate endpoint.
     pub fn endpoint(&self) -> String {
         format!("{}/api/generate", self.server)
     }
 
+    /// Refresh interval in minutes, clamped to the 1-60 range.
     pub fn refresh_minutes(&self) -> u64 {
         let mins = self.refresh.as_secs() / 60;
         if mins == 0 {
@@ -295,6 +299,7 @@ impl AiConfig {
         }
     }
 
+    /// Human-readable label for the current refresh mode.
     pub fn refresh_mode_label(&self) -> &'static str {
         match self.refresh_mode {
             crate::config::AiRefreshMode::AutoAndManual => "Auto & Manual",
@@ -302,6 +307,7 @@ impl AiConfig {
         }
     }
 
+    /// Normalize a server address: default to localhost, add an http scheme, strip trailing slashes.
     pub fn normalized_server(enabled: bool, server: &str) -> String {
         let mut value = server.trim().to_string();
         if value.is_empty() {
@@ -317,6 +323,7 @@ impl AiConfig {
 }
 
 impl AiOutcome {
+    /// Build a successful outcome carrying the generated content.
     pub fn success(model: &str, content: String) -> Self {
         Self {
             model: model.to_string(),
@@ -326,6 +333,7 @@ impl AiOutcome {
         }
     }
 
+    /// Build a failed outcome from an error, with a summarized message.
     pub fn from_error(model: &str, err: anyhow::Error) -> Self {
         Self {
             model: model.to_string(),
@@ -335,6 +343,7 @@ impl AiOutcome {
         }
     }
 
+    /// Replace the outcome's error with a summarized version of `message`.
     pub fn with_error_message(mut self, message: String) -> Self {
         self.error = Some(summarize_error(&message));
         self

--- a/src/astro/coordinates.rs
+++ b/src/astro/coordinates.rs
@@ -1,4 +1,7 @@
-// Coordinate transformation utilities
+//! Coordinate system transformation utilities.
+//!
+//! Helpers for converting between astronomical coordinate representations,
+//! such as azimuth angles to compass directions.
 
 /// Convert altitude-azimuth to compass bearing
 pub fn azimuth_to_compass(azimuth: f64) -> &'static str {

--- a/src/astro/mod.rs
+++ b/src/astro/mod.rs
@@ -34,8 +34,10 @@ pub use units::{Altitude, Azimuth, DEG_TO_RAD, Degrees, RAD_TO_DEG, Radians};
 /// All calculations assume sea level (0m elevation) per USNO celestial navigation convention
 #[derive(Debug, Clone, Copy)]
 pub struct Location {
-    pub latitude: Latitude,   // positive North
-    pub longitude: Longitude, // positive East
+    /// Geographic latitude (positive North).
+    pub latitude: Latitude,
+    /// Geographic longitude (positive East).
+    pub longitude: Longitude,
 }
 
 impl Location {

--- a/src/astro/time_utils.rs
+++ b/src/astro/time_utils.rs
@@ -1,4 +1,6 @@
-// Time utilities for astronomical calculations
+//! Time and duration utilities for astronomical calculations.
+//!
+//! Formatting helpers for displaying durations and countdowns to events.
 
 use chrono::{DateTime, Duration, TimeZone};
 

--- a/src/astro/units.rs
+++ b/src/astro/units.rs
@@ -27,10 +27,12 @@ pub const RAD_TO_DEG: f64 = 180.0 / PI;
 pub struct Degrees(f64);
 
 impl Degrees {
+    /// Create an angle from a value in degrees.
     pub fn new(value: f64) -> Self {
         Self(value)
     }
 
+    /// Return the underlying numeric value as a bare `f64`.
     pub fn value(&self) -> f64 {
         self.0
     }
@@ -55,18 +57,22 @@ impl Degrees {
         Self(result)
     }
 
+    /// Convert this angle to [`Radians`].
     pub fn to_radians(self) -> Radians {
         Radians::from(self)
     }
 
+    /// Sine of the angle.
     pub fn sin(self) -> f64 {
         self.0.to_radians().sin()
     }
 
+    /// Cosine of the angle.
     pub fn cos(self) -> f64 {
         self.0.to_radians().cos()
     }
 
+    /// Tangent of the angle.
     pub fn tan(self) -> f64 {
         self.0.to_radians().tan()
     }
@@ -97,38 +103,47 @@ impl From<Degrees> for f64 {
 pub struct Radians(f64);
 
 impl Radians {
+    /// Create an angle from a value in radians.
     pub fn new(value: f64) -> Self {
         Self(value)
     }
 
+    /// Return the underlying numeric value as a bare `f64`.
     pub fn value(&self) -> f64 {
         self.0
     }
 
+    /// Convert this angle to [`Degrees`].
     pub fn to_degrees(self) -> Degrees {
         Degrees::from(self)
     }
 
+    /// Sine of the angle.
     pub fn sin(self) -> f64 {
         self.0.sin()
     }
 
+    /// Cosine of the angle.
     pub fn cos(self) -> f64 {
         self.0.cos()
     }
 
+    /// Tangent of the angle.
     pub fn tan(self) -> f64 {
         self.0.tan()
     }
 
+    /// Arcsine of a value, as an angle in radians.
     pub fn asin(value: f64) -> Self {
         Self(value.asin())
     }
 
+    /// Arccosine of a value, as an angle in radians.
     pub fn acos(value: f64) -> Self {
         Self(value.acos())
     }
 
+    /// Four-quadrant arctangent of `y/x`, as an angle in radians.
     pub fn atan2(y: f64, x: f64) -> Self {
         Self(y.atan2(x))
     }
@@ -154,6 +169,7 @@ impl From<Radians> for Degrees {
 pub struct Latitude(f64);
 
 impl Latitude {
+    /// Create a latitude from decimal degrees, validating the -90 to 90 range.
     pub fn new(degrees: f64) -> Result<Self, String> {
         if !(-90.0..=90.0).contains(&degrees) {
             Err(format!("Invalid latitude: {} (must be -90 to 90)", degrees))
@@ -167,14 +183,17 @@ impl Latitude {
         Self(degrees)
     }
 
+    /// Return this value as a type-safe [`Degrees`] angle.
     pub fn degrees(&self) -> Degrees {
         Degrees(self.0)
     }
 
+    /// Return this value as a type-safe [`Radians`] angle.
     pub fn radians(&self) -> Radians {
         Radians(self.0 * DEG_TO_RAD)
     }
 
+    /// Return the underlying numeric value as a bare `f64`.
     pub fn value(&self) -> f64 {
         self.0
     }
@@ -199,6 +218,7 @@ impl fmt::Display for Latitude {
 pub struct Longitude(f64);
 
 impl Longitude {
+    /// Create a longitude from decimal degrees, validating the -180 to 180 range.
     pub fn new(degrees: f64) -> Result<Self, String> {
         if !(-180.0..=180.0).contains(&degrees) {
             Err(format!(
@@ -215,14 +235,17 @@ impl Longitude {
         Self(degrees)
     }
 
+    /// Return this value as a type-safe [`Degrees`] angle.
     pub fn degrees(&self) -> Degrees {
         Degrees(self.0)
     }
 
+    /// Return this value as a type-safe [`Radians`] angle.
     pub fn radians(&self) -> Radians {
         Radians(self.0 * DEG_TO_RAD)
     }
 
+    /// Return the underlying numeric value as a bare `f64`.
     pub fn value(&self) -> f64 {
         self.0
     }
@@ -249,22 +272,27 @@ impl fmt::Display for Longitude {
 pub struct Altitude(f64);
 
 impl Altitude {
+    /// Create an altitude from decimal degrees above (positive) or below (negative) the horizon.
     pub fn from_degrees(degrees: f64) -> Self {
         Self(degrees)
     }
 
+    /// Create an altitude from a value in radians.
     pub fn from_radians(radians: f64) -> Self {
         Self(radians * RAD_TO_DEG)
     }
 
+    /// Return this value as a type-safe [`Degrees`] angle.
     pub fn degrees(&self) -> Degrees {
         Degrees(self.0)
     }
 
+    /// Return this value as a type-safe [`Radians`] angle.
     pub fn radians(&self) -> Radians {
         Radians(self.0 * DEG_TO_RAD)
     }
 
+    /// Return the underlying numeric value as a bare `f64`.
     pub fn value(&self) -> f64 {
         self.0
     }
@@ -287,6 +315,7 @@ impl fmt::Display for Altitude {
 pub struct Azimuth(f64);
 
 impl Azimuth {
+    /// Create an azimuth from decimal degrees, normalizing into the 0-360 range.
     pub fn from_degrees(degrees: f64) -> Self {
         // Normalize to 0-360
         let mut normalized = degrees % 360.0;
@@ -296,22 +325,27 @@ impl Azimuth {
         Self(normalized)
     }
 
+    /// Create an azimuth from a value in radians, normalizing into the 0-360 degree range.
     pub fn from_radians(radians: f64) -> Self {
         Self::from_degrees(radians * RAD_TO_DEG)
     }
 
+    /// Return this value as a type-safe [`Degrees`] angle.
     pub fn degrees(&self) -> Degrees {
         Degrees(self.0)
     }
 
+    /// Return this value as a type-safe [`Radians`] angle.
     pub fn radians(&self) -> Radians {
         Radians(self.0 * DEG_TO_RAD)
     }
 
+    /// Return the underlying numeric value as a bare `f64`.
     pub fn value(&self) -> f64 {
         self.0
     }
 
+    /// Return the nearest 8-point compass direction (N, NE, E, SE, S, SW, W, NW).
     pub fn to_compass(&self) -> &'static str {
         let index = ((self.0 + 22.5) / 45.0).floor() as usize % 8;
         ["N", "NE", "E", "SE", "S", "SW", "W", "NW"][index]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@
 //! RUSTFLAGS="-C target-cpu=native" cargo build --release
 //! ```
 
+#![warn(missing_docs)]
+
 // Core modules (always public)
 pub mod astro;
 pub mod city;
@@ -363,12 +365,19 @@ pub fn batch_calculate<Tz: TimeZone + Clone>(
 /// Result from batch calculations.
 #[derive(Debug, Clone)]
 pub struct BatchResult<Tz: TimeZone> {
+    /// The date/time the calculations were performed for.
     pub date: DateTime<Tz>,
+    /// Sun position (altitude, azimuth) at `date`.
     pub sun_position: SolarPosition,
+    /// Moon position (altitude, azimuth, phase, distance) at `date`.
     pub moon_position: LunarPosition,
+    /// Sunrise time, or `None` during polar night/day.
     pub sunrise: Option<DateTime<Tz>>,
+    /// Sunset time, or `None` during polar night/day.
     pub sunset: Option<DateTime<Tz>>,
+    /// Moonrise time, or `None` if the moon doesn't rise on this date.
     pub moonrise: Option<DateTime<Tz>>,
+    /// Moonset time, or `None` if the moon doesn't set on this date.
     pub moonset: Option<DateTime<Tz>>,
 }
 
@@ -398,8 +407,11 @@ pub fn library_info() -> LibraryInfo {
 /// Library information structure.
 #[derive(Debug, Clone)]
 pub struct LibraryInfo {
+    /// Crate version string (from `CARGO_PKG_VERSION`).
     pub version: &'static str,
+    /// CPU optimization profile detected at runtime.
     pub cpu_profile: cpu_features::OptimizationProfile,
+    /// Number of cities in the built-in city database.
     pub city_count: usize,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,8 +120,13 @@ fn main() -> Result<()> {
         return Ok(());
     }
     #[cfg(feature = "usno-validation")]
-    if args.validate {
+    let run_validation = args.validate;
+    #[cfg(not(feature = "usno-validation"))]
+    let run_validation = false;
+
+    if run_validation {
         // Validation mode - compare with USNO data
+        #[cfg(feature = "usno-validation")]
         {
             let report = solunatus::usno_validation::generate_validation_report(
                 &location,
@@ -170,12 +175,6 @@ fn main() -> Result<()> {
                     .filter(|r| r.status == solunatus::usno_validation::ValidationStatus::Missing)
                     .count()
             );
-        }
-        #[cfg(not(feature = "usno-validation"))]
-        {
-            eprintln!("Error: USNO validation feature not enabled.");
-            eprintln!("Rebuild with: cargo build --features usno-validation");
-            std::process::exit(1);
         }
     } else if args.json {
         // JSON output mode

--- a/tests/planet_accuracy.rs
+++ b/tests/planet_accuracy.rs
@@ -1,0 +1,119 @@
+//! Regression tests pinning planet positions to JPL Horizons reference data.
+//!
+//! Reference values were obtained from the JPL Horizons API
+//! (<https://ssd.jpl.nasa.gov/api/horizons.api>) for an observer at
+//! Boston, USA (42.3601 N, 71.0589 W, 0 m), quantities 4 and 20
+//! (airless apparent azimuth/elevation and observer range), at three
+//! epochs spanning the validity range of the Keplerian mean elements.
+//!
+//! A live drift check against Horizons also runs on a schedule in CI
+//! (`.github/workflows/planet-validation.yml`, via
+//! `scripts/planet_drift_check.py`); these offline tests guard the
+//! algorithm itself on every build without network access.
+
+use chrono::TimeZone;
+use chrono_tz::UTC;
+use solunatus::astro::Location;
+use solunatus::astro::planets::{Planet, planet_position};
+
+/// Maximum allowed angular deviation from Horizons, in degrees.
+///
+/// Observed deviations across 1990-2049 are below 0.06 degrees; 0.1 leaves
+/// margin without masking a real regression (0.1 degrees of sky motion is
+/// roughly 24 seconds of rise/set time).
+const MAX_ANGLE_DEG: f64 = 0.1;
+
+/// Maximum allowed relative error in the observer-to-planet distance.
+const MAX_DIST_FRAC: f64 = 0.005;
+
+const BOSTON_LAT: f64 = 42.3601;
+const BOSTON_LON: f64 = -71.0589;
+
+/// (planet, azimuth deg, altitude deg, distance AU) from JPL Horizons.
+type Reference = (Planet, f64, f64, f64);
+
+fn angle_delta(a: f64, b: f64) -> f64 {
+    let d = (a - b).abs() % 360.0;
+    d.min(360.0 - d)
+}
+
+fn check_epoch(epoch_utc: (i32, u32, u32, u32, u32, u32), references: &[Reference]) {
+    let (y, mo, d, h, mi, s) = epoch_utc;
+    let location = Location::new(BOSTON_LAT, BOSTON_LON).unwrap();
+    let datetime = UTC.with_ymd_and_hms(y, mo, d, h, mi, s).unwrap();
+
+    for &(planet, ref_az, ref_alt, ref_dist) in references {
+        let pos = planet_position(planet, &location, &datetime);
+        let d_az = angle_delta(pos.azimuth, ref_az);
+        let d_alt = (pos.altitude - ref_alt).abs();
+        let d_dist = (pos.distance_au - ref_dist).abs() / ref_dist;
+
+        assert!(
+            d_az <= MAX_ANGLE_DEG,
+            "{} azimuth off by {d_az:.4} deg at {datetime} (got {:.4}, Horizons {ref_az:.4})",
+            planet.name(),
+            pos.azimuth,
+        );
+        assert!(
+            d_alt <= MAX_ANGLE_DEG,
+            "{} altitude off by {d_alt:.4} deg at {datetime} (got {:.4}, Horizons {ref_alt:.4})",
+            planet.name(),
+            pos.altitude,
+        );
+        assert!(
+            d_dist <= MAX_DIST_FRAC,
+            "{} distance off by {:.3}% at {datetime} (got {:.6} AU, Horizons {ref_dist:.6} AU)",
+            planet.name(),
+            d_dist * 100.0,
+            pos.distance_au,
+        );
+    }
+}
+
+#[test]
+fn matches_horizons_1990() {
+    check_epoch(
+        (1990, 1, 15, 17, 0, 0),
+        &[
+            (Planet::Mercury, 197.8003, 26.0687, 0.711146),
+            (Planet::Venus, 176.8579, 32.8724, 0.268181),
+            (Planet::Mars, 217.3456, 14.8610, 2.223391),
+            (Planet::Jupiter, 24.6306, -20.3256, 4.230633),
+            (Planet::Saturn, 190.2963, 24.9273, 10.999333),
+            (Planet::Uranus, 201.2080, 21.1390, 20.311998),
+            (Planet::Neptune, 195.4946, 24.1108, 31.168747),
+        ],
+    );
+}
+
+#[test]
+fn matches_horizons_2026() {
+    check_epoch(
+        (2026, 6, 15, 16, 0, 0),
+        &[
+            (Planet::Mercury, 109.3974, 53.1921, 0.824931),
+            (Planet::Venus, 98.5039, 41.7830, 1.155799),
+            (Planet::Mars, 227.6540, 57.3981, 2.148972),
+            (Planet::Jupiter, 104.0132, 46.0910, 6.100534),
+            (Planet::Saturn, 250.8763, 24.1420, 9.745155),
+            (Planet::Uranus, 208.6130, 65.9907, 20.400931),
+            (Planet::Neptune, 255.4212, 16.0938, 30.035179),
+        ],
+    );
+}
+
+#[test]
+fn matches_horizons_2049() {
+    check_epoch(
+        (2049, 12, 1, 17, 0, 0),
+        &[
+            (Planet::Mercury, 166.4200, 20.5501, 1.172121),
+            (Planet::Venus, 194.3629, 26.1557, 1.693783),
+            (Planet::Mars, 232.0988, 21.5957, 2.249341),
+            (Planet::Jupiter, 310.9630, -11.9117, 4.592380),
+            (Planet::Saturn, 140.3109, 15.6994, 10.669645),
+            (Planet::Uranus, 268.8551, 7.9026, 18.438850),
+            (Planet::Neptune, 24.2892, -26.9989, 28.866532),
+        ],
+    );
+}


### PR DESCRIPTION
## Summary

Release preparation for **v0.6.0** (version already bumped in Cargo.toml by #74).

### 100% API documentation coverage
- docs.rs coverage was ~86% on the 0.5.0 release; this PR documents all remaining public items (`astro::units` wrappers, `ai` config methods, `BatchResult`/`LibraryInfo` fields, `coordinates`/`time_utils` module docs)
- Verified with `cargo +nightly rustdoc -- --show-coverage`: **494/494 items, 100.0%** in every file
- `#![warn(missing_docs)]` added so future public items can't ship undocumented

### Planet accuracy validation vs JPL Horizons (gold standard)
- Validated the new planets module against the JPL Horizons ephemeris at five epochs spanning 1990–2049: **all alt/az within 0.06°** (≈ a few seconds of rise/set time), distances within 0.41%, magnitudes within 0.25 mag (except Venus as a thin crescent near inferior conjunction, a known limit of simple magnitude formulas)
- `tests/planet_accuracy.rs`: offline regression tests pinning Horizons reference values at 3 epochs — runs on every build, no network needed
- `.github/workflows/planet-validation.yml` + `scripts/planet_drift_check.py`: scheduled weekly live drift check against the Horizons API, mirroring the USNO drift workflow

### Bug fix: `--no-default-features` builds produced no output
A misplaced `#[cfg(feature = "usno-validation")]` on the output-mode dispatch compiled out JSON/watch/text modes entirely — the binary silently exited. The gate now applies only to the `--validate` branch.

### Release housekeeping
- CHANGELOG: `[Unreleased]` → `[0.6.0] - 2026-06-10` with new entries
- README refreshed for the 0.6.0 feature set (planets, seasons, golden hour, ICS, `--next`, completions/manpage) and the Horizons validation results
- `cargo publish --dry-run` passes (84 files, 461.5 KiB compressed)

## Test plan
- [x] `cargo test` — 45 unit + 3 planet accuracy + 44 doc tests pass
- [x] `cargo clippy --all-features` — clean
- [x] `cargo build --release --no-default-features` + JSON output verified
- [x] `scripts/planet_drift_check.py` run locally against live Horizons (5 epochs, all PASS)
- [x] `cargo publish --dry-run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)