### PR TITLE
docs(changelog): record clap_complete 4.6.7 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Dependencies**: Bumped `ratatui` from 0.30.1 to 0.30.2 via the production-dependencies group (Dependabot PR #77); pulls in the refreshed `ratatui-core`/`-crossterm`/`-macros`/`-widgets` 0.1.2/0.7.2/0.3.2 stack and the new optional `ratatui-termina` backend (unused here). Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 - **Dependencies**: Bumped `anyhow` from 1.0.102 to 1.0.103 via the production-dependencies group (Dependabot PR #79); upstream fixes a Stacked Borrows violation (undefined behavior surfaced under Miri) in `Error::downcast_mut`. Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
+- **Dependencies**: Bumped `clap_complete` from 4.6.5 to 4.6.7 via the production-dependencies group (Dependabot PR #82); adds `pwsh` detection to shell-completion generation. Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 
 ## [0.6.0] - 2026-06-10
 


### PR DESCRIPTION
## Summary
- Records the `clap_complete` bump from 4.6.5 → 4.6.7 (#82, merged) in the `Unreleased` → `Changed` section of CHANGELOG.md.
- Completes routine repository maintenance: both open Dependabot PRs (#81 codeql-action, #82 clap_complete) are now reviewed and merged, plus a freshly-published RustSec advisory (RUSTSEC-2026-0204, crossbeam-epoch) found during CI was remediated in #83.

## Test plan
- [x] No code changes; CHANGELOG.md only.
- [x] Verified PR #82 merged cleanly with all CI checks (including Rust Security Audit and Pin Drift Check) green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SUc2KESc2hmPaxvjhDzzkr)_