### PR TITLE
release: prepare 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-20
+
 ### Security
 - **Dependencies**: Bumped the transitive `quinn-proto` from 0.11.14 to 0.11.15 to remediate **RUSTSEC-2026-0185** (CVSS 7.5, high) — a remote memory-exhaustion flaw from unbounded out-of-order QUIC stream reassembly. `quinn-proto` reaches the tree only through the optional reqwest HTTP stack (behind the `usno-validation` / `ai-insights` features); lockfile-only, no `Cargo.toml` constraints changed, and `cargo audit` is clean again
 - **CI**: Advanced the `actions/checkout` pinned SHA from `df4cb1c` (v6.0.3) to `9c091bb` (v7.0.0) across all workflows and retargeted the Pin Drift Check to the `v7` tag (Dependabot PR #76). v7.0.0 hardens supply-chain safety by blocking checkout of fork pull requests under the `pull_request_target` and `workflow_run` triggers; the SHA pin and `Security Workflow Audit` / `Pin Drift Check` gates remain green
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependencies**: Bumped `ratatui` from 0.30.1 to 0.30.2 via the production-dependencies group (Dependabot PR #77); pulls in the refreshed `ratatui-core`/`-crossterm`/`-macros`/`-widgets` 0.1.2/0.7.2/0.3.2 stack and the new optional `ratatui-termina` backend (unused here). Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 - **Dependencies**: Bumped `anyhow` from 1.0.102 to 1.0.103 via the production-dependencies group (Dependabot PR #79); upstream fixes a Stacked Borrows violation (undefined behavior surfaced under Miri) in `Error::downcast_mut`. Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 - **Dependencies**: Bumped `clap_complete` from 4.6.5 to 4.6.7 via the production-dependencies group (Dependabot PR #82); adds `pwsh` detection to shell-completion generation. Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
+- **Dependencies**: Bumped `clap` 4.6.1 → 4.6.2, `serde` 1.0.228 → 1.0.229, `serde_json` 1.0.150 → 1.0.151, and `anyhow` 1.0.103 → 1.0.104 via the production-dependencies group (Dependabot PR #88). Lockfile-only; no `Cargo.toml` constraints changed and `cargo audit` reports no known advisories
 
 ## [0.6.0] - 2026-06-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "solunatus"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solunatus"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Mike McLarney"]

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Add dependency:
 
 ```toml
 [dependencies]
-solunatus = "0.6.0"
+solunatus = "0.6.1"
 chrono = "0.4"
 chrono-tz = "0.10"
 ```


### PR DESCRIPTION
## Summary
- Version bump 0.6.0 → 0.6.1 — a maintenance release consolidating the security/dependency/CI work accumulated since 0.6.0.
- CHANGELOG `[Unreleased]` moved to `[0.6.1] - 2026-07-20`.
- No functional/API changes; 100% doc coverage maintained.

### Included since 0.6.0
- Security: `quinn-proto` RUSTSEC-2026-0185 fix, `crossbeam-epoch` RUSTSEC-2026-0204 fix
- CI: `actions/checkout` pin advanced to v7.0.1, `codeql-action` pin advanced to v4.37.0
- Dependencies: `ratatui` 0.30.2, `anyhow` 1.0.104, `clap` 4.6.2, `clap_complete` 4.6.7, `serde` 1.0.229, `serde_json` 1.0.151

## Test plan
- [x] `cargo test --all-features` (44 doctests + unit/integration) passes
- [x] `cargo clippy --all-features` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --no-default-features` + JSON smoke test
- [x] `cargo +nightly rustdoc --show-coverage` → 100%
- [x] `cargo audit` clean
- [x] Local `cargo publish --dry-run` packages successfully