### PR TITLE
ci(security): refresh stale dtolnay/rust-toolchain SHA pin

### DIFF
--- a/.github/workflows/planet-validation.yml
+++ b/.github/workflows/planet-validation.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - name: Build solunatus
         run: cargo build --release --locked --no-default-features
       - name: Run planet drift check against JPL Horizons

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - name: Build
         run: cargo build --verbose --locked
 
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.91.1
       - name: Build with MSRV
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           components: clippy
       - name: Run clippy
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           components: rustfmt
       - name: Check formatting
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - name: Test default feature set
         run: cargo test --verbose --locked
       - name: Test all features
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - name: Build docs
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run cargo audit
@@ -74,6 +74,18 @@ jobs:
             echo "${sha}"
           }
 
+          resolve_branch_commit() {
+            local repo="$1"
+            local branch="$2"
+            local sha
+            sha="$(git ls-remote "https://github.com/${repo}.git" "refs/heads/${branch}" | awk '{print $1}')"
+            if [[ -z "${sha}" ]]; then
+              echo "Unable to resolve ${repo}@${branch}" >&2
+              exit 1
+            fi
+            echo "${sha}"
+          }
+
           resolve_local_pin() {
             local pattern="$1"
             local sha
@@ -112,6 +124,21 @@ jobs:
             failures=1
           else
             echo "OK: github/codeql-action matches v4 (${codeql_expected})"
+          fi
+
+          # dtolnay/rust-toolchain has no tags; "stable" etc. are branches that
+          # get force-pushed to a new commit on every Rust release, so a pin
+          # left unrefreshed eventually points at a commit unreachable from
+          # any branch (Dependabot then fails with "no such commit").
+          toolchain_expected="$(resolve_branch_commit "dtolnay/rust-toolchain" "stable")"
+          toolchain_pinned="$(resolve_local_pin 'uses:[[:space:]]*dtolnay/rust-toolchain@[a-f0-9]{40}')"
+          if [[ "${toolchain_pinned}" != "${toolchain_expected}" ]]; then
+            echo "Pin drift: dtolnay/rust-toolchain"
+            echo "  pinned:   ${toolchain_pinned}"
+            echo "  expected: ${toolchain_expected} (stable)"
+            failures=1
+          else
+            echo "OK: dtolnay/rust-toolchain matches stable (${toolchain_expected})"
           fi
 
           if [[ "${failures}" -ne 0 ]]; then

--- a/.github/workflows/usno-validation.yml
+++ b/.github/workflows/usno-validation.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - name: Build solunatus
         run: cargo build --release --locked --no-default-features --features usno-validation
       - name: Run USNO validation gates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **CI**: Refreshed the `dtolnay/rust-toolchain` SHA pin (used in `rust.yml`, `security.yml`, `usno-validation.yml`, and `planet-validation.yml`) from `631a55b` to the current `stable` branch tip `4cda84d`. The old pin had never been updated since it was first added and had gone stale: `dtolnay/rust-toolchain` ships no tags, only branches (`stable`, `beta`, `nightly`, version branches) that are force-pushed to a new commit on every Rust release, so an unrefreshed SHA pin eventually points at a commit unreachable from any branch tip. This was silently breaking the weekly `github-actions` Dependabot update job (`error: no such commit 631a55b...`, recurring since at least 2026-07-14) and risked a hard CI failure once GitHub garbage-collected the orphaned commit
+- **CI**: Extended the `Pin Drift Check` workflow job to also track `dtolnay/rust-toolchain` against its `stable` branch (previously it only covered `actions/checkout` and `github/codeql-action`, both of which were confirmed still current), so a future rebase of the `stable` branch is caught automatically instead of failing silently in Dependabot
+
 ## [0.6.1] - 2026-07-20
 
 ### Security


### PR DESCRIPTION
## Summary
- The `dtolnay/rust-toolchain` SHA pin (`631a55b`) used across `rust.yml`, `security.yml`, `usno-validation.yml`, and `planet-validation.yml` had never been updated since it was first added, and had drifted off that repo's `stable` branch history. `dtolnay/rust-toolchain` ships no tags — only branches (`stable`, `beta`, `nightly`, version branches) that get force-pushed to a new commit on every Rust release — so an unrefreshed SHA pin eventually points at a commit unreachable from any branch tip.
- This was silently failing the weekly `github_actions` Dependabot update job since at least 2026-07-14 (`error: no such commit 631a55b...`), and risked a hard CI break once GitHub garbage-collected the orphaned commit.
- Updated all 9 references across the 4 workflow files to the current `stable` tip (`4cda84d`).
- Extended the `Pin Drift Check` job in `security.yml` to also track `dtolnay/rust-toolchain` against its `stable` branch going forward, alongside the existing `actions/checkout` (v7) and `github/codeql-action` (v4) checks — both of which were verified still current and not drifted.
- Recorded the fix in `CHANGELOG.md` under `[Unreleased] / Security`.

## Test plan
- [x] `cargo build --release` succeeds
- [x] Verified the new `dtolnay/rust-toolchain@stable` pin resolves via `git ls-remote` and matches what's now checked in
- [x] Verified `actions/checkout@v7` and `github/codeql-action@v4` pins are still current (no drift) via `git ls-remote`
- [ ] CI (Rust CI / Security / CodeQL) to confirm green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bM736qqiGopbZTMjxLVsH

---
_Generated by [Claude Code](https://claude.ai/code/session_014bM736qqiGopbZTMjxLVsH)_